### PR TITLE
Fix LGTM.com build for Java analysis

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,6 +1,7 @@
 extraction:
   java:
+    prepare:
+      packages:
+        - graphviz
     index:
-      build_command: mvn install -Prelease-site -Dmaven.test.failure.ignore=true -DfailIfNoTests=false -Dmaven.javadoc.skip=true -B -V -q -Dtest=no
-      maven: 
-        version: 3.5.2
+      build_command: mvn clean package -f "pom.xml" -B -e -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dmaven.test.skip.exec -t /opt/work/.m2/toolchains.xml -pl '!cia-dist-deb,!cia-dist-cloudformation'


### PR DESCRIPTION
I noticed that you guys started using LGTM.com code analytics and automated code review [for CIA](https://lgtm.com/projects/g/Hack23/cia/), but that the Java code wasn't being analysed due to the fact that LGTM didn't quite know how to build your code. This configuration change should fix the build.

As soon as this is merged, I'll enable Java analysis for CIA. As soon as LGTM has analysed the most recent revision, it'll also automatically start posting automated code reviews for Java.

I suggest that you merge the build command as-is, and do any tweaking in a follow-up PR. That'll make debugging build failures a lot easier :slightly_smiling_face:.

Any questions/comments/feedback: give me a shout. Keep up the good work!

(full disclosure: I'm part of the team that built LGTM.com)