### PR TITLE
use DestinationSecurityGroupId for egres rules

### DIFF
--- a/cia-dist-cloudformation/src/main/resources/cia-dist-cloudformation.json
+++ b/cia-dist-cloudformation/src/main/resources/cia-dist-cloudformation.json
@@ -2449,7 +2449,7 @@
                         "IpProtocol": "tcp",
                         "FromPort": "5432",
                         "ToPort": "5432",
-                        "SourceSecurityGroupId": {
+                        "DestinationSecurityGroupId": {
                             "Ref": "WebServerSecurityGroup"
                         }
                     }
@@ -4274,7 +4274,7 @@
                         "IpProtocol": "tcp",
                         "FromPort": "8443",
                         "ToPort": "8443",
-                        "SourceSecurityGroupId": {
+                        "DestinationSecurityGroupId": {
                             "Ref": "PublicLoadBalancerSecurityGroup"
                         }
                     },


### PR DESCRIPTION
ourceSecurityGroupId property has been deprecated for AWS::EC2::SecurityGroup.SecurityGroupEgress. Please use DestinationSecurityGroupId

By submitting a request, you represent that you have the right to license
your contribution to the community, and agree that your contributions are
licensed under the [The Apache Software License, Version 2.0](LICENSE.txt).
