### PR TITLE
Update panel caption to use embeddedId.concern

### DIFF
--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/ballot/pagemode/BallotChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/ballot/pagemode/BallotChartsPageModContentFactoryImpl.java
@@ -8,7 +8,7 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed on an "AS IS" BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -144,7 +144,7 @@ public final class BallotChartsPageModContentFactoryImpl extends AbstractBallotP
 				}
 
 
-				panel.setCaption(new StringBuilder().append("Ballot Charts for pageId: ").append(pageId).toString());
+				panel.setCaption(new StringBuilder().append("Ballot Charts for concern: ").append(ballots.get(0).getEmbeddedId().getConcern()).toString());
 				getPageActionEventHelper().createPageEvent(ViewAction.VISIT_BALLOT_VIEW, ApplicationEventGroup.USER, NAME, parameters, pageId);
 			}
 		return panelContent;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/ballot/pagemode/BallotOverviewPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/ballot/pagemode/BallotOverviewPageModContentFactoryImpl.java
@@ -163,7 +163,7 @@ public final class BallotOverviewPageModContentFactoryImpl extends AbstractBallo
 			getBallotMenuItemFactory().createOverviewPage(overviewLayout, pageId);
 
 
-			panel.setCaption(new StringBuilder().append("Ballot Overview for pageId: ").append(pageId).toString());
+			panel.setCaption(new StringBuilder().append("Ballot Overview for concern: ").append(ballots.get(0).getEmbeddedId().getConcern()).toString());
 			getPageActionEventHelper().createPageEvent(ViewAction.VISIT_BALLOT_VIEW, ApplicationEventGroup.USER, NAME,
 					parameters, pageId);
 		}

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeBallotDecisionSummaryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeBallotDecisionSummaryPageModContentFactoryImpl.java
@@ -7,7 +7,6 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
  *distributed under the License is distributed on an "AS IS" BASIS,
  *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *See the License for the specific language governing permissions and
@@ -108,7 +107,7 @@ extends AbstractCommitteePageModContentFactoryImpl {
 				COMMITTEE_BALLOT_DECISION_SUMMARY, NESTED_PROPERTIES, COLUMN_ORDER, HIDE_COLUMNS, LISTENER, BALLOT_ID,
 				null);
 
-		panel.setCaption(new StringBuilder().append("Committee Ballot Decision Summary for ").append(viewRiksdagenCommittee.getEmbeddedId().getDetail()).toString());
+		panel.setCaption(new StringBuilder().append("Committee Ballot Decision Summary for concern: ").append(viewRiksdagenCommittee.getEmbeddedId().getConcern()).toString());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_COMMITTEE_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 		return panelContent;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyCommitteeBallotDecisionSummaryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyCommitteeBallotDecisionSummaryPageModContentFactoryImpl.java
@@ -7,14 +7,13 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *See the License for the specific language governing permissions and
+ *limitations under the License.
  *
- *	$Id$
- *  $HeadURL$
+ *$Id$
+ *$HeadURL$
 */
 package com.hack23.cia.web.impl.ui.application.views.user.party.pagemode;
 
@@ -110,6 +109,8 @@ public final class PartyCommitteeBallotDecisionSummaryPageModContentFactoryImpl
 				ViewRiksdagenCommitteeBallotDecisionPartySummary.class, decisionPartySummaryList,
 				COMMITTEE_BALLOT_DECISION_PARTY_SUMMARY, NESTED_PROPERTIES, COLUMN_ORDER, HIDE_COLUMNS, LISTENER,
 				BALLOT_ID, null);
+
+		panel.setCaption(new StringBuilder().append("Committee Ballot Decision Summary for concern: ").append(viewRiksdagenParty.getEmbeddedId().getConcern()).toString());
 
 		pageCompleted(parameters, panel, pageId, viewRiksdagenParty);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/politician/pagemode/PoliticianBallotDecisionSummaryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/politician/pagemode/PoliticianBallotDecisionSummaryPageModContentFactoryImpl.java
@@ -7,14 +7,13 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *See the License for the specific language governing permissions and
+ *limitations under the License.
  *
- *	$Id$
- *  $HeadURL$
+ *$Id$
+ *$HeadURL$
 */
 package com.hack23.cia.web.impl.ui.application.views.user.politician.pagemode;
 
@@ -98,6 +97,7 @@ public final class PoliticianBallotDecisionSummaryPageModContentFactoryImpl
 				COMMITTEE_BALLOT_DECISION_POLITICIAN_SUMMARY, NESTED_PROPERTIES, COLUMN_ORDER, HIDE_COLUMNS, LISTENER,
 				BALLOT_ID, null);
 
+		panel.setCaption(new StringBuilder().append("Politician Ballot Decision Summary for concern: ").append(viewRiksdagenPolitician.getEmbeddedId().getConcern()).toString());
 
 		pageCompleted(parameters, panel, pageId, viewRiksdagenPolitician);
 


### PR DESCRIPTION
Update panel captions to use `embeddedId.concern` instead of `pageId` for better context.

* In `BallotOverviewPageModContentFactoryImpl.java`, update the panel caption to use `ballots.get(0).getEmbeddedId().getConcern()`.
* In `CommitteeBallotDecisionSummaryPageModContentFactoryImpl.java`, update the panel caption to use `viewRiksdagenCommittee.getEmbeddedId().getConcern()`.
* In `PartyCommitteeBallotDecisionSummaryPageModContentFactoryImpl.java`, update the panel caption to use `viewRiksdagenParty.getEmbeddedId().getConcern()`.
* In `PoliticianBallotDecisionSummaryPageModContentFactoryImpl.java`, update the panel caption to use `viewRiksdagenPolitician.getEmbeddedId().getConcern()`.
* In `BallotChartsPageModContentFactoryImpl.java`, update the panel caption to use `ballots.get(0).getEmbeddedId().getConcern()`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/cia/pull/6780?shareId=dce454fc-7e3c-4b3d-821a-0c5e97069316).