### PR TITLE
Update page headers and descriptions

### DIFF
--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeCurrentMembersHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeCurrentMembersHistoryPageModContentFactoryImpl.java
@@ -28,7 +28,6 @@ import com.hack23.cia.model.internal.application.data.committee.impl.ViewRiksdag
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.service.api.DataContainer;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
-import com.hack23.cia.web.impl.ui.application.views.common.labelfactory.LabelFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.CommitteePageMode;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 import com.hack23.cia.web.impl.ui.application.views.pageclicklistener.PageItemPropertyClickListener;
@@ -76,7 +75,7 @@ public final class CommitteeCurrentMembersHistoryPageModContentFactoryImpl
 		final ViewRiksdagenCommittee viewRiksdagenCommittee = getItem(parameters);
 		getCommitteeMenuItemFactory().createCommitteeeMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, CURRENT_MEMBERS);
+		createPageHeader(panel, panelContent, "Committee History " + viewRiksdagenCommittee.getEmbeddedId().getDetail(), "Current Members History", "Tracks and presents historical data about committee members' participation.");
 
 		final DataContainer<ViewRiksdagenCommitteeRoleMember, String> committeeRoleMemberDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenCommitteeRoleMember.class);
@@ -87,7 +86,6 @@ public final class CommitteeCurrentMembersHistoryPageModContentFactoryImpl
 						ViewRiksdagenCommitteeRoleMember_.detail, ViewRiksdagenCommitteeRoleMember_.active),
 				CURRENT_MEMBERS, COLUMN_ORDER, HIDE_COLUMNS, LISTENER, null, null);
 
-		panel.setCaption(NAME + "::" + COMMITTEE + viewRiksdagenCommittee.getEmbeddedId().getDetail());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_COMMITTEE_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 		return panelContent;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeDecisionTypeDailySummaryPageModContentFactoryImpl2.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeDecisionTypeDailySummaryPageModContentFactoryImpl2.java
@@ -27,7 +27,6 @@ import com.hack23.cia.model.internal.application.data.committee.impl.ViewRiksdag
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
 import com.hack23.cia.web.impl.ui.application.views.common.chartfactory.api.DecisionChartDataManager;
-import com.hack23.cia.web.impl.ui.application.views.common.labelfactory.LabelFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.CommitteePageMode;
 import com.vaadin.ui.Layout;
 import com.vaadin.ui.MenuBar;
@@ -40,9 +39,6 @@ import com.vaadin.ui.VerticalLayout;
 @Component
 public final class CommitteeDecisionTypeDailySummaryPageModContentFactoryImpl2
 		extends AbstractCommitteePageModContentFactoryImpl {
-
-	/** The Constant DECISION_TYPE_DAILY_SUMMARY. */
-	private static final String DECISION_TYPE_DAILY_SUMMARY = "Decision Type Daily Summary";
 
 	/** The chart data manager. */
 	@Autowired
@@ -66,11 +62,10 @@ public final class CommitteeDecisionTypeDailySummaryPageModContentFactoryImpl2
 		final ViewRiksdagenCommittee viewRiksdagenCommittee = getItem(parameters);
 		getCommitteeMenuItemFactory().createCommitteeeMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, DECISION_TYPE_DAILY_SUMMARY);
+		createPageHeader(panel, panelContent, "Daily Committee Decisions " + viewRiksdagenCommittee.getEmbeddedId().getDetail() , "Summary of Decision Types", "Displays a summary of daily committee decision-making activity.");
 
 		chartDataManager.createDecisionTypeChart(panelContent, viewRiksdagenCommittee.getEmbeddedId().getOrgCode());
 
-		panel.setCaption(new StringBuilder().append("Committee Decision Type Daily Summary for ").append(viewRiksdagenCommittee.getEmbeddedId().getDetail()).toString());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_COMMITTEE_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 		return panelContent;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeDocumentActivityPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeDocumentActivityPageModContentFactoryImpl.java
@@ -27,7 +27,6 @@ import com.hack23.cia.model.internal.application.data.committee.impl.ViewRiksdag
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
 import com.hack23.cia.web.impl.ui.application.views.common.chartfactory.api.OrgDocumentChartDataManager;
-import com.hack23.cia.web.impl.ui.application.views.common.labelfactory.LabelFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.CommitteePageMode;
 import com.vaadin.ui.Layout;
 import com.vaadin.ui.MenuBar;
@@ -69,12 +68,11 @@ public final class CommitteeDocumentActivityPageModContentFactoryImpl
 		final ViewRiksdagenCommittee viewRiksdagenCommittee = getItem(parameters);
 		getCommitteeMenuItemFactory().createCommitteeeMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, DOCUMENT_ACTIVITY);
+		createPageHeader(panel, panelContent, "Committee Documents " + viewRiksdagenCommittee.getEmbeddedId().getDetail() , "Document Activity Overview", "Tracks and visualizes the activity associated with committee documents.");
 
 		chartDataManager.createDocumentHistoryChartByOrg(panelContent,
 				viewRiksdagenCommittee.getEmbeddedId().getOrgCode());
 
-		panel.setCaption(NAME + "::" + COMMITTEE + viewRiksdagenCommittee.getEmbeddedId().getDetail());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_COMMITTEE_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 		return panelContent;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeDocumentHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeDocumentHistoryPageModContentFactoryImpl.java
@@ -28,7 +28,6 @@ import com.hack23.cia.model.internal.application.data.document.impl.ViewRiksdage
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.service.api.DataContainer;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
-import com.hack23.cia.web.impl.ui.application.views.common.labelfactory.LabelFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.CommitteePageMode;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 import com.hack23.cia.web.impl.ui.application.views.pageclicklistener.PageItemPropertyClickListener;
@@ -78,7 +77,7 @@ public final class CommitteeDocumentHistoryPageModContentFactoryImpl
 
 		getCommitteeMenuItemFactory().createCommitteeeMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, DOCUMENT_HISTORY);
+		createPageHeader(panel, panelContent, "Document History " + viewRiksdagenCommittee.getEmbeddedId().getDetail(), "Committee Document History", "Displays the historical progression of documents managed by committees.");
 
 		final DataContainer<ViewRiksdagenPoliticianDocument, String> politicianDocumentDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenPoliticianDocument.class);
@@ -91,7 +90,6 @@ public final class CommitteeDocumentHistoryPageModContentFactoryImpl
 								ViewRiksdagenPoliticianDocument_.madePublicDate),
 						DOCUMENTS, COLUMN_ORDER, HIDE_COLUMNS, LISTENER, null, null);
 
-		panel.setCaption(new StringBuilder().append("Committee Document History for ").append(viewRiksdagenCommittee.getEmbeddedId().getDetail()).toString());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_COMMITTEE_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 		return panelContent;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeMemberHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeMemberHistoryPageModContentFactoryImpl.java
@@ -28,7 +28,6 @@ import com.hack23.cia.model.internal.application.data.committee.impl.ViewRiksdag
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.service.api.DataContainer;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
-import com.hack23.cia.web.impl.ui.application.views.common.labelfactory.LabelFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.CommitteePageMode;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 import com.hack23.cia.web.impl.ui.application.views.pageclicklistener.PageItemPropertyClickListener;
@@ -76,7 +75,7 @@ public final class CommitteeMemberHistoryPageModContentFactoryImpl extends Abstr
 
 		getCommitteeMenuItemFactory().createCommitteeeMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, MEMBER_HISTORY);
+		createPageHeader(panel, panelContent, "Member History " + viewRiksdagenCommittee.getEmbeddedId().getDetail(), "Committee Member Participation History", "Analyzes and presents participation trends for committee members.");
 
 		final DataContainer<ViewRiksdagenCommitteeRoleMember, String> committeeRoleMemberDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenCommitteeRoleMember.class);
@@ -86,7 +85,6 @@ public final class CommitteeMemberHistoryPageModContentFactoryImpl extends Abstr
 						viewRiksdagenCommittee.getEmbeddedId().getDetail()),
 				MEMBER_HISTORY, COLUMN_ORDER, HIDE_COLUMNS, LISTENER, null, null);
 
-		panel.setCaption(NAME + "::" + COMMITTEE + viewRiksdagenCommittee.getEmbeddedId().getDetail());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_COMMITTEE_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 		return panelContent;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeOverviewPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeOverviewPageModContentFactoryImpl.java
@@ -28,7 +28,6 @@ import org.springframework.stereotype.Component;
 import com.hack23.cia.model.internal.application.data.committee.impl.ViewRiksdagenCommittee;
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
-import com.hack23.cia.web.impl.ui.application.views.common.labelfactory.LabelFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.sizing.ContentRatio;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PageMode;
 import com.vaadin.ui.Layout;
@@ -67,7 +66,7 @@ public final class CommitteeOverviewPageModContentFactoryImpl extends AbstractCo
 
 		getCommitteeMenuItemFactory().createCommitteeeMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, OVERVIEW);
+		createPageHeader(panel, panelContent, "Committee Overview " + viewRiksdagenCommittee.getEmbeddedId().getDetail(), "Committee Operations Overview", "Provides an overview of committee operations for decision-making support.");
 
 		final Link addCommitteePageLink = getPageLinkFactory().addCommitteePageLink(viewRiksdagenCommittee);
 		panelContent.addComponent(addCommitteePageLink);
@@ -85,7 +84,6 @@ public final class CommitteeOverviewPageModContentFactoryImpl extends AbstractCo
 
 		panelContent.setExpandRatio(addCommitteePageLink, ContentRatio.SMALL);
 
-		panel.setCaption(new StringBuilder().append("Committee Overview for ").append(viewRiksdagenCommittee.getEmbeddedId().getDetail()).toString());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_COMMITTEE_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 		return panelContent;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteePageVisitHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteePageVisitHistoryPageModContentFactoryImpl.java
@@ -59,9 +59,10 @@ public final class CommitteePageVisitHistoryPageModContentFactoryImpl
 		final ViewRiksdagenCommittee viewRiksdagenCommittee = getItem(parameters);
 		getCommitteeMenuItemFactory().createCommitteeeMenuBar(menuBar, pageId);
 
+		createPageHeader(panel, panelContent, "Committee Visits", "Page Visit History for Committees", "Tracks user interaction with committee pages for analytical purposes.");
+
 		createPageVisitHistory(NAME, pageId, panelContent);
 
-		panel.setCaption(NAME + "::" + COMMITTEE + viewRiksdagenCommittee.getEmbeddedId().getDetail());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_COMMITTEE_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 		return panelContent;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeRankingAllCommitteesChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committee/pagemode/CommitteeRankingAllCommitteesChartsPageModContentFactoryImpl.java
@@ -71,14 +71,14 @@ public final class CommitteeRankingAllCommitteesChartsPageModContentFactoryImpl
 
 		final String pageId = getPageId(parameters);
 
+		createPageHeader(panel, panelContent, "Committee Rankings", "Ranking of All Committees", "Provides comparative rankings for committees based on performance or metrics.");
+
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
 		chartDataManager.createChartPanel(chartLayout, dataSeriesFactory.createCommitteeChartTimeSeriesAll(), "All");
 
 		panelContent.addComponent(chartLayout);
-
-		panel.setCaption("All Committees Charts Overview");
 
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_COMMITTEE_RANKING_VIEW, ApplicationEventGroup.USER,
 				NAME, parameters, pageId);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryCurrentMembersPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryCurrentMembersPageModContentFactoryImpl.java
@@ -28,7 +28,6 @@ import com.hack23.cia.model.internal.application.data.ministry.impl.ViewRiksdage
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.service.api.DataContainer;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
-import com.hack23.cia.web.impl.ui.application.views.common.labelfactory.LabelFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.MinistryPageMode;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 import com.hack23.cia.web.impl.ui.application.views.pageclicklistener.PageItemPropertyClickListener;
@@ -73,7 +72,7 @@ public final class MinistryCurrentMembersPageModContentFactoryImpl extends Abstr
 
 		getMinistryMenuItemFactory().createMinistryMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, CURRENT_MEMBERS);
+		createPageHeader(panel, panelContent, "Ministry Members " + viewRiksdagenMinistry.getNameId(), "Current Members of Ministry", "Details the current composition of ministry members.");
 
 		final DataContainer<ViewRiksdagenGovermentRoleMember, String> govermentRoleMemberDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenGovermentRoleMember.class);
@@ -84,7 +83,6 @@ public final class MinistryCurrentMembersPageModContentFactoryImpl extends Abstr
 						ViewRiksdagenGovermentRoleMember_.detail, ViewRiksdagenGovermentRoleMember_.active),
 				CURRENT_MEMBERS, COLUMN_ORDER, HIDE_COLUMNS, LISTENER, null, null);
 
-		panel.setCaption(new StringBuilder().append("Ministry Current Members for ").append(viewRiksdagenMinistry.getNameId()).toString());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryDocumentActivityPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryDocumentActivityPageModContentFactoryImpl.java
@@ -27,7 +27,6 @@ import com.hack23.cia.model.internal.application.data.ministry.impl.ViewRiksdage
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
 import com.hack23.cia.web.impl.ui.application.views.common.chartfactory.api.OrgDocumentChartDataManager;
-import com.hack23.cia.web.impl.ui.application.views.common.labelfactory.LabelFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.MinistryPageMode;
 import com.vaadin.ui.Layout;
 import com.vaadin.ui.MenuBar;
@@ -68,11 +67,10 @@ public final class MinistryDocumentActivityPageModContentFactoryImpl extends Abs
 		final ViewRiksdagenMinistry viewRiksdagenMinistry = getItem(parameters);
 		getMinistryMenuItemFactory().createMinistryMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, DOCUMENT_ACTIVITY);
+		createPageHeader(panel, panelContent, "Ministry Documents " + viewRiksdagenMinistry.getNameId(), "Document Activity Overview", "Tracks and visualizes the activity associated with ministry documents.");
 
 		chartDataManager.createDocumentHistoryChartByOrg(panelContent, viewRiksdagenMinistry.getNameId());
 
-		panel.setCaption(NAME + "::" + MINISTRY + viewRiksdagenMinistry.getNameId());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryDocumentHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryDocumentHistoryPageModContentFactoryImpl.java
@@ -28,7 +28,6 @@ import com.hack23.cia.model.internal.application.data.ministry.impl.ViewRiksdage
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.service.api.DataContainer;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
-import com.hack23.cia.web.impl.ui.application.views.common.labelfactory.LabelFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.MinistryPageMode;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 import com.hack23.cia.web.impl.ui.application.views.pageclicklistener.PageItemPropertyClickListener;
@@ -77,7 +76,7 @@ public final class MinistryDocumentHistoryPageModContentFactoryImpl extends Abst
 
 		getMinistryMenuItemFactory().createMinistryMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, DOCUMENT_HISTORY);
+		createPageHeader(panel, panelContent, "Document History " + viewRiksdagenMinistry.getNameId(), "Ministry Document History", "Displays the historical progression of documents managed by ministries.");
 
 		final DataContainer<ViewRiksdagenPoliticianDocument, String> politicianDocumentDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenPoliticianDocument.class);
@@ -87,7 +86,6 @@ public final class MinistryDocumentHistoryPageModContentFactoryImpl extends Abst
 						viewRiksdagenMinistry.getNameId(), ViewRiksdagenPoliticianDocument_.madePublicDate),
 				DOCUMENTS, COLUMN_ORDER, HIDE_COLUMNS, LISTENER, null, null);
 
-		panel.setCaption(new StringBuilder().append("Ministry Document History for ").append(viewRiksdagenMinistry.getNameId()).toString());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryGovernmentBodiesExpenditureModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryGovernmentBodiesExpenditureModContentFactoryImpl.java
@@ -27,7 +27,6 @@ import com.hack23.cia.model.internal.application.data.ministry.impl.ViewRiksdage
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
 import com.hack23.cia.web.impl.ui.application.views.common.chartfactory.api.GovernmentBodyChartDataManager;
-import com.hack23.cia.web.impl.ui.application.views.common.labelfactory.LabelFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.MinistryPageMode;
 import com.vaadin.ui.Layout;
 import com.vaadin.ui.MenuBar;
@@ -39,11 +38,6 @@ import com.vaadin.ui.VerticalLayout;
  */
 @Component
 public final class MinistryGovernmentBodiesExpenditureModContentFactoryImpl extends AbstractMinistryPageModContentFactoryImpl {
-
-	private static final String GOVERNMENT_BODIES = "Government bodies spending";
-
-	/** The Constant MINISTRY. */
-	private static final String MINISTRY = "Ministry:";
 
 	@Autowired
 	private GovernmentBodyChartDataManager governmentBodyChartDataManager;
@@ -66,12 +60,11 @@ public final class MinistryGovernmentBodiesExpenditureModContentFactoryImpl exte
 		final ViewRiksdagenMinistry viewRiksdagenMinistry = getItem(parameters);
 		getMinistryMenuItemFactory().createMinistryMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, GOVERNMENT_BODIES);
+		createPageHeader(panel, panelContent, "Expenditure Analysis " + viewRiksdagenMinistry.getNameId(), "Government Bodies Expenditure Analysis", "Provides detailed expenditure data for government bodies under ministries.");
 
 		governmentBodyChartDataManager.createMinistryGovernmentBodyExpenditureSummaryChart(panelContent,
 				viewRiksdagenMinistry.getNameId());
 
-		panel.setCaption(NAME + "::" + MINISTRY + viewRiksdagenMinistry.getNameId());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 


### PR DESCRIPTION
Update `createPageHeader` method calls in various `PageModContentFactoryImpl` classes to use new header, page header, and description values instead of `panel.setCaption` and `LabelFactory.createHeader`.

* **CommitteeCurrentMembersHistoryPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader`.
  - Update `createPageHeader` call to use "Committee History", "Current Members History", and "Tracks and presents historical data about committee members' participation."
  - Remove `panel.setCaption` call.

* **CommitteeDecisionTypeDailySummaryPageModContentFactoryImpl2.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader`.
  - Update `createPageHeader` call to use "Daily Committee Decisions", "Summary of Decision Types", and "Displays a summary of daily committee decision-making activity."
  - Remove `panel.setCaption` call.

* **CommitteeDocumentActivityPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader`.
  - Update `createPageHeader` call to use "Committee Documents", "Document Activity Overview", and "Tracks and visualizes the activity associated with committee documents."
  - Remove `panel.setCaption` call.

* **CommitteeDocumentHistoryPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader`.
  - Update `createPageHeader` call to use "Document History", "Committee Document History", and "Displays the historical progression of documents managed by committees."
  - Remove `panel.setCaption` call.

* **CommitteeMemberHistoryPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader`.
  - Update `createPageHeader` call to use "Member History", "Committee Member Participation History", and "Analyzes and presents participation trends for committee members."
  - Remove `panel.setCaption` call.

* **CommitteeOverviewPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader`.
  - Update `createPageHeader` call to use "Committee Overview", "Committee Operations Overview", and "Provides an overview of committee operations for decision-making support."
  - Remove `panel.setCaption` call.

* **CommitteePageVisitHistoryPageModContentFactoryImpl.java**
  - Add `createPageHeader` call.
  - Use "Committee Visits", "Page Visit History for Committees", and "Tracks user interaction with committee pages for analytical purposes." in `createPageHeader` call.
  - Remove `panel.setCaption` call.

* **CommitteeRankingAllCommitteesChartsPageModContentFactoryImpl.java**
  - Add `createPageHeader` call.
  - Use "Committee Rankings", "Ranking of All Committees", and "Provides comparative rankings for committees based on performance or metrics." in `createPageHeader` call.
  - Remove `panel.setCaption` call.

* **MinistryCurrentMembersPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader`.
  - Update `createPageHeader` call to use "Ministry Members", "Current Members of Ministry", and "Details the current composition of ministry members."
  - Remove `panel.setCaption` call.

* **MinistryDocumentActivityPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader`.
  - Update `createPageHeader` call to use "Ministry Documents", "Document Activity Overview", and "Tracks and visualizes the activity associated with ministry documents."
  - Remove `panel.setCaption` call.

* **MinistryDocumentHistoryPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader`.
  - Update `createPageHeader` call to use "Document History", "Ministry Document History", and "Displays the historical progression of documents managed by ministries."
  - Remove `panel.setCaption` call.

* **MinistryGovernmentBodiesExpenditureModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader`.
  - Update `createPageHeader` call to use "Expenditure Analysis", "Government Bodies Expenditure Analysis", and "Provides detailed expenditure data for government bodies under ministries."
  - Remove `panel.setCaption` call.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/cia/pull/6804?shareId=80a66af0-04f6-4241-ab6e-2320599fbca2).