### PR TITLE
Fix page header usage in government page mode classes

### DIFF
--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryGovernmentBodiesHeadcountModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryGovernmentBodiesHeadcountModContentFactoryImpl.java
@@ -27,7 +27,6 @@ import com.hack23.cia.model.internal.application.data.ministry.impl.ViewRiksdage
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
 import com.hack23.cia.web.impl.ui.application.views.common.chartfactory.api.GovernmentBodyChartDataManager;
-import com.hack23.cia.web.impl.ui.application.views.common.labelfactory.LabelFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.MinistryPageMode;
 import com.vaadin.ui.Layout;
 import com.vaadin.ui.MenuBar;
@@ -63,12 +62,11 @@ public final class MinistryGovernmentBodiesHeadcountModContentFactoryImpl extend
 		final ViewRiksdagenMinistry viewRiksdagenMinistry = getItem(parameters);
 		getMinistryMenuItemFactory().createMinistryMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, GOVERNMENT_BODIES);
+		createPageHeader(panel, panelContent, "Ministry Government Bodies Headcount " + viewRiksdagenMinistry.getNameId(), "Government Bodies Headcount", "Provides detailed headcount data for government bodies under ministries.");
 
 		governmentBodyChartDataManager.createMinistryGovernmentBodyHeadcountSummaryChart(panelContent,
 				viewRiksdagenMinistry.getNameId());
 
-		panel.setCaption(new StringBuilder().append("Ministry Government Bodies Headcount for ").append(viewRiksdagenMinistry.getNameId()).toString());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryGovernmentBodiesIncomeModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryGovernmentBodiesIncomeModContentFactoryImpl.java
@@ -27,8 +27,6 @@ import com.hack23.cia.model.internal.application.data.ministry.impl.ViewRiksdage
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
 import com.hack23.cia.web.impl.ui.application.views.common.chartfactory.api.GovernmentBodyChartDataManager;
-import com.hack23.cia.web.impl.ui.application.views.common.labelfactory.LabelFactory;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.MinistryPageMode;
 import com.vaadin.ui.Layout;
 import com.vaadin.ui.MenuBar;
 import com.vaadin.ui.Panel;
@@ -66,12 +64,11 @@ public final class MinistryGovernmentBodiesIncomeModContentFactoryImpl extends A
 		final ViewRiksdagenMinistry viewRiksdagenMinistry = getItem(parameters);
 		getMinistryMenuItemFactory().createMinistryMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, GOVERNMENT_BODIES);
+		createPageHeader(panel, panelContent, "Government Bodies Income " + viewRiksdagenMinistry.getNameId(), "Government Bodies Income", "Provides detailed income data for government bodies under ministries.");
 
 		governmentBodyChartDataManager.createMinistryGovernmentBodyIncomeSummaryChart(panelContent,
 				viewRiksdagenMinistry.getNameId());
 
-		panel.setCaption(NAME + "::" + MINISTRY + viewRiksdagenMinistry.getNameId());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryGovernmentBodiesIncomeModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryGovernmentBodiesIncomeModContentFactoryImpl.java
@@ -27,6 +27,7 @@ import com.hack23.cia.model.internal.application.data.ministry.impl.ViewRiksdage
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
 import com.hack23.cia.web.impl.ui.application.views.common.chartfactory.api.GovernmentBodyChartDataManager;
+import com.hack23.cia.web.impl.ui.application.views.common.viewnames.MinistryPageMode;
 import com.vaadin.ui.Layout;
 import com.vaadin.ui.MenuBar;
 import com.vaadin.ui.Panel;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryMemberHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryMemberHistoryPageModContentFactoryImpl.java
@@ -72,7 +72,7 @@ public final class MinistryMemberHistoryPageModContentFactoryImpl extends Abstra
 
 		getMinistryMenuItemFactory().createMinistryMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, MEMBER_HISTORY);
+		createPageHeader(panel, panelContent, "Ministry Member History " + viewRiksdagenMinistry.getNameId(), "Member History", "Details the historical composition of ministry members.");
 
 		final DataContainer<ViewRiksdagenGovermentRoleMember, String> govermentRoleMemberDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenGovermentRoleMember.class);
@@ -82,7 +82,6 @@ public final class MinistryMemberHistoryPageModContentFactoryImpl extends Abstra
 						viewRiksdagenMinistry.getNameId()),
 				MEMBER_HISTORY, COLUMN_ORDER, HIDE_COLUMNS, LISTENER, null, null);
 
-		panel.setCaption(new StringBuilder().append("Ministry Member History for ").append(viewRiksdagenMinistry.getNameId()).toString());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryPageVisitHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryPageVisitHistoryPageModContentFactoryImpl.java
@@ -55,9 +55,10 @@ public final class MinistryPageVisitHistoryPageModContentFactoryImpl extends Abs
 		final ViewRiksdagenMinistry viewRiksdagenMinistry = getItem(parameters);
 		getMinistryMenuItemFactory().createMinistryMenuBar(menuBar, pageId);
 
+		createPageHeader(panel, panelContent, "Ministry Page Visit History " + viewRiksdagenMinistry.getNameId(), "Page Visit History", "Tracks and visualizes the history of page visits for ministries.");
+
 		createPageVisitHistory(NAME, pageId, panelContent);
 
-		panel.setCaption(new StringBuilder().append("Ministry Page Visit History for ").append(viewRiksdagenMinistry.getNameId()).toString());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingAllMinistriesChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingAllMinistriesChartsPageModContentFactoryImpl.java
@@ -70,6 +70,8 @@ public final class MinistryRankingAllMinistriesChartsPageModContentFactoryImpl
 
 		final String pageId = getPageId(parameters);
 
+		createPageHeader(panel, panelContent, "Ministry Rankings", "All Ministries", "Visual representation of all ministries and their total headcount.");
+
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
@@ -77,7 +79,6 @@ public final class MinistryRankingAllMinistriesChartsPageModContentFactoryImpl
 
 		panelContent.addComponent(chartLayout);
 
-		panel.setCaption(NAME + "::" + CHARTS + parameters);
 
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_RANKING_VIEW, ApplicationEventGroup.USER,
 				NAME, parameters, pageId);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingAllPartiesChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingAllPartiesChartsPageModContentFactoryImpl.java
@@ -70,6 +70,8 @@ public final class MinistryRankingAllPartiesChartsPageModContentFactoryImpl
 
 		final String pageId = getPageId(parameters);
 
+		createPageHeader(panel, panelContent, "Ministry Rankings", "All Parties", "Visual representation of all parties and their total days served.");
+
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
@@ -79,7 +81,6 @@ public final class MinistryRankingAllPartiesChartsPageModContentFactoryImpl
 
 		panelContent.addComponent(chartLayout);
 
-		panel.setCaption(NAME + "::" + CHARTS + parameters);
 
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_RANKING_VIEW, ApplicationEventGroup.USER,
 				NAME, parameters, pageId);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingAllRolesChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingAllRolesChartsPageModContentFactoryImpl.java
@@ -68,6 +68,8 @@ public final class MinistryRankingAllRolesChartsPageModContentFactoryImpl
 
 		final String pageId = getPageId(parameters);
 
+		createPageHeader(panel, panelContent, "Ministry Rankings", "All Roles", "Visual representation of all government roles.");
+
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
@@ -78,7 +80,6 @@ public final class MinistryRankingAllRolesChartsPageModContentFactoryImpl
 
 		ministryGhantChartManager.createRoleGhant(panelContent, allMembers);
 
-		panel.setCaption(NAME + "::" + CHARTS + parameters);
 
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_RANKING_VIEW, ApplicationEventGroup.USER,
 				NAME, parameters, pageId);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingCurrentPartiesChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingCurrentPartiesChartsPageModContentFactoryImpl.java
@@ -69,6 +69,7 @@ public final class MinistryRankingCurrentPartiesChartsPageModContentFactoryImpl 
 
 		final String pageId = getPageId(parameters);
 
+		createPageHeader(panel, panelContent, "Ministry Rankings", "Current Parties", "Visual representation of current parties and their headcount.");
 
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
@@ -78,7 +79,6 @@ public final class MinistryRankingCurrentPartiesChartsPageModContentFactoryImpl 
 
 		panelContent.addComponent(chartLayout);
 
-		panel.setCaption(NAME + "::" + CHARTS + parameters);
 
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_RANKING_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModContentFactoryImpl.java
@@ -103,6 +103,8 @@ public final class MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModCon
 
 		final String pageId = getPageId(parameters);
 
+		createPageHeader(panel, panelContent, "Ministry Rankings", "Leader Scoreboard", "Visual representation of ministry leaders and their performance.");
+
 		LabelFactory.createHeader2Label(panelContent, "Dashboard Government members");
 
 		final Label descriptionLabel = new Label(
@@ -139,7 +141,6 @@ public final class MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModCon
 
 		}
 
-		panel.setCaption(NAME + "::" + CHARTS + parameters);
 
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_RANKING_VIEW, ApplicationEventGroup.USER,
 				NAME, parameters, pageId);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingGovernmentBodiesPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingGovernmentBodiesPageModContentFactoryImpl.java
@@ -61,6 +61,7 @@ public final class MinistryRankingGovernmentBodiesPageModContentFactoryImpl exte
 
 		final String pageId = getPageId(parameters);
 
+		createPageHeader(panel, panelContent, "Government Bodies", "Government Body Headcount", "Provides detailed headcount data for government bodies under ministries.");
 
 		panel.setCaption(NAME + "::" + GOVERNMENT_BODIES + parameters);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingGovernmentBodyExpenditurePageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingGovernmentBodyExpenditurePageModContentFactoryImpl.java
@@ -62,7 +62,8 @@ public final class MinistryRankingGovernmentBodyExpenditurePageModContentFactory
 
 		final String pageId = getPageId(parameters);
 
-		panel.setCaption(NAME + "::" + GOVERNMENT_BODIES + parameters);
+		createPageHeader(panel, panelContent, "Government Bodies Expenditure", "Government Body Expenditure", "Provides detailed expenditure data for government bodies under ministries.");
+
 
 		governmentBodyChartDataManager.createMinistryGovernmentBodyExpenditureSummaryChart(panelContent);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingGovernmentBodyIncomePageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingGovernmentBodyIncomePageModContentFactoryImpl.java
@@ -62,7 +62,8 @@ public final class MinistryRankingGovernmentBodyIncomePageModContentFactoryImpl 
 
 		final String pageId = getPageId(parameters);
 
-		panel.setCaption(NAME + "::" + GOVERNMENT_BODIES + parameters);
+		createPageHeader(panel, panelContent, "Government Bodies Income", "Government Body Income", "Provides detailed income data for government bodies under ministries.");
+
 
 		governmentBodyChartDataManager.createMinistryGovernmentBodyIncomeSummaryChart(panelContent);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingPageVisitHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingPageVisitHistoryPageModContentFactoryImpl.java
@@ -57,9 +57,10 @@ public final class MinistryRankingPageVisitHistoryPageModContentFactoryImpl
 
 		final String pageId = getPageId(parameters);
 
+		createPageHeader(panel, panelContent, "Ministry Rankings", "Page Visit History", "Tracks and visualizes the history of page visits for ministry rankings.");
+
 		getAdminChartDataManager().createApplicationActionEventPageModeDailySummaryChart(panelContent,NAME);
 
-		panel.setCaption(NAME + "::" + PAGE_VISIT_HISTORY);
 
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_RANKING_VIEW, ApplicationEventGroup.USER,
 				NAME, parameters, pageId);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRoleGhantPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRoleGhantPageModContentFactoryImpl.java
@@ -71,7 +71,7 @@ public final class MinistryRoleGhantPageModContentFactoryImpl extends AbstractMi
 		final ViewRiksdagenMinistry viewRiksdagenMinistry = getItem(parameters);
 		getMinistryMenuItemFactory().createMinistryMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, ROLE_GHANT);
+		createPageHeader(panel, panelContent, "Ministry Role Ghant " + viewRiksdagenMinistry.getNameId(), "Role Ghant", "Visual representation of ministry roles over time.");
 
 		final DataContainer<ViewRiksdagenGovermentRoleMember, String> govermentRoleMemberDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenGovermentRoleMember.class);
@@ -81,7 +81,6 @@ public final class MinistryRoleGhantPageModContentFactoryImpl extends AbstractMi
 
 		ministryGhantChartManager.createRoleGhant(panelContent, allMembers);
 
-		panel.setCaption(NAME + "::" + MINISTRY + viewRiksdagenMinistry.getNameId());
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);
 		return panelContent;


### PR DESCRIPTION
Add `createPageHeader` calls with descriptive values after creating the menubar in various classes under `citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/`.

* **MinistryGovernmentBodiesHeadcountModContentFactoryImpl.java**
  - Add `createPageHeader` call after creating the menubar with descriptive values.
  - Remove `panel.setCaption` call.

* **MinistryGovernmentBodiesIncomeModContentFactoryImpl.java**
  - Add `createPageHeader` call after creating the menubar with descriptive values.
  - Remove `panel.setCaption` call.

* **MinistryMemberHistoryPageModContentFactoryImpl.java**
  - Add `createPageHeader` call after creating the menubar with descriptive values.
  - Remove `panel.setCaption` call.

* **MinistryPageVisitHistoryPageModContentFactoryImpl.java**
  - Add `createPageHeader` call after creating the menubar with descriptive values.
  - Remove `panel.setCaption` call.

* **MinistryRankingAllMinistriesChartsPageModContentFactoryImpl.java**
  - Add `createPageHeader` call after creating the menubar with descriptive values.
  - Remove `panel.setCaption` call.

* **MinistryRankingAllPartiesChartsPageModContentFactoryImpl.java**
  - Add `createPageHeader` call after creating the menubar with descriptive values.
  - Remove `panel.setCaption` call.

* **MinistryRankingAllRolesChartsPageModContentFactoryImpl.java**
  - Add `createPageHeader` call after creating the menubar with descriptive values.
  - Remove `panel.setCaption` call.

* **MinistryRankingCurrentPartiesChartsPageModContentFactoryImpl.java**
  - Add `createPageHeader` call after creating the menubar with descriptive values.
  - Remove `panel.setCaption` call.

* **MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModContentFactoryImpl.java**
  - Add `createPageHeader` call after creating the menubar with descriptive values.
  - Remove `panel.setCaption` call.

* **MinistryRankingGovernmentBodiesPageModContentFactoryImpl.java**
  - Add `createPageHeader` call after creating the menubar with descriptive values.

* **MinistryRankingGovernmentBodyExpenditurePageModContentFactoryImpl.java**
  - Add `createPageHeader` call after creating the menubar with descriptive values.

* **MinistryRankingGovernmentBodyIncomePageModContentFactoryImpl.java**
  - Add `createPageHeader` call after creating the menubar with descriptive values.

* **MinistryRankingPageVisitHistoryPageModContentFactoryImpl.java**
  - Add `createPageHeader` call after creating the menubar with descriptive values.
  - Remove `panel.setCaption` call.

* **MinistryRoleGhantPageModContentFactoryImpl.java**
  - Add `createPageHeader` call after creating the menubar with descriptive values.
  - Remove `panel.setCaption` call.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/cia/pull/6809?shareId=e455eae3-ecc4-4c53-b165-d35157983ec1).