### PR TITLE
Update page header usage in government body page mode

### DIFF
--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyExpenditurePageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyExpenditurePageModContentFactoryImpl.java
@@ -74,11 +74,10 @@ public final class GovernmentBodyExpenditurePageModContentFactoryImpl extends Ab
 			if (governmentBodyAnnualSummary != null) {
 				getGovernmentBodyMenuItemFactory().createGovernmentBodyMenuBar(menuBar, pageId,governmentBodyAnnualSummary.getName());
 
-				LabelFactory.createHeader2Label(panelContent,GOVERNMENT_BODIES + governmentBodyAnnualSummary.getName());
+				createPageHeader(panel, panelContent, "Government Body Expenditure " + governmentBodyAnnualSummary.getName(), "Expenditure Details", "Explore detailed expenditure information for government bodies.");				LabelFactory.createHeader2Label(panelContent,GOVERNMENT_BODIES + governmentBodyAnnualSummary.getName());
 
 				governmentBodyChartDataManager.createGovernmentBodyExpenditureSummaryChart(panelContent, governmentBodyAnnualSummary.getName());
 
-				panel.setCaption(GOVERNMENT_BODY + ":" + governmentBodyAnnualSummary.getName());
 
 			}
 			getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_VIEW, ApplicationEventGroup.USER, NAME,

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyHeadcountPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyHeadcountPageModContentFactoryImpl.java
@@ -72,9 +72,8 @@ public final class GovernmentBodyHeadcountPageModContentFactoryImpl extends Abst
 
 			if (governmentBodyAnnualSummary != null) {
 				getGovernmentBodyMenuItemFactory().createGovernmentBodyMenuBar(menuBar, pageId,governmentBodyAnnualSummary.getName());
-				LabelFactory.createHeader2Label(panelContent,GOVERNMENT_BODIES + governmentBodyAnnualSummary.getName());
+				createPageHeader(panel, panelContent, "Government Body Headcount " + governmentBodyAnnualSummary.getName(), "Headcount Details", "Explore detailed headcount information for government bodies.");
 				governmentBodyChartDataManager.createGovernmentBodyHeadcountSummaryChart(panelContent, governmentBodyAnnualSummary.getName());
-				panel.setCaption(GOVERNMENT_BODY + ":" + governmentBodyAnnualSummary.getName());
 			}
 			getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_VIEW, ApplicationEventGroup.USER, NAME,
 					parameters, pageId);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyIncomePageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyIncomePageModContentFactoryImpl.java
@@ -73,9 +73,8 @@ public final class GovernmentBodyIncomePageModContentFactoryImpl extends Abstrac
 
 			if (governmentBodyAnnualSummary != null) {
 				getGovernmentBodyMenuItemFactory().createGovernmentBodyMenuBar(menuBar, pageId,governmentBodyAnnualSummary.getName());
-				LabelFactory.createHeader2Label(panelContent,GOVERNMENT_BODIES + governmentBodyAnnualSummary.getName());
+				createPageHeader(panel, panelContent, "Government Body Income " + governmentBodyAnnualSummary.getName(), "Income Details", "Explore detailed income information for government bodies.");
 				governmentBodyChartDataManager.createGovernmentBodyIncomeSummaryChart(panelContent, governmentBodyAnnualSummary.getName());
-				panel.setCaption(GOVERNMENT_BODY + ":"+ governmentBodyAnnualSummary.getName());
 			}
 
 			getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_VIEW, ApplicationEventGroup.USER, NAME,

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyPageVisitHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyPageVisitHistoryPageModContentFactoryImpl.java
@@ -61,9 +61,9 @@ public final class GovernmentBodyPageVisitHistoryPageModContentFactoryImpl
 
 		getGovernmentBodyMenuItemFactory().createGovernmentBodyMenuBar(menuBar, pageId,pageId);
 
-		getAdminChartDataManager().createApplicationActionEventPageModeDailySummaryChart(panelContent,NAME);
+		createPageHeader(panel, panelContent, "Government Body Page Visit History", "Page Visit History", "Track the visit history of government body pages.");
 
-		panel.setCaption(NAME + "::" + PAGE_VISIT_HISTORY);
+		getAdminChartDataManager().createApplicationActionEventPageModeDailySummaryChart(panelContent,NAME);
 
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_GOVERNMENT_BODY_VIEW, ApplicationEventGroup.USER,
 				NAME, parameters, pageId);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyRankingExpenditurePageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyRankingExpenditurePageModContentFactoryImpl.java
@@ -62,7 +62,7 @@ public final class GovernmentBodyRankingExpenditurePageModContentFactoryImpl ext
 
 		final String pageId = getPageId(parameters);
 
-		panel.setCaption(NAME + "::" + GOVERNMENT_BODIES + parameters);
+		createPageHeader(panel, panelContent, "Government Body Expenditure", "Expenditure Details", "Explore detailed expenditure information for government bodies.");
 
 		governmentBodyChartDataManager.createGovernmentBodyExpenditureSummaryChart(panelContent);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyRankingHeadCountPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyRankingHeadCountPageModContentFactoryImpl.java
@@ -62,7 +62,7 @@ public final class GovernmentBodyRankingHeadCountPageModContentFactoryImpl exten
 
 		final String pageId = getPageId(parameters);
 
-		panel.setCaption(NAME + "::" + GOVERNMENT_BODIES + parameters);
+		createPageHeader(panel, panelContent, "Government Body Headcount", "Headcount Details", "Explore detailed headcount information for government bodies.");
 
 		governmentBodyChartDataManager.createGovernmentBodyHeadcountSummaryChart(panelContent);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyRankingIncomePageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyRankingIncomePageModContentFactoryImpl.java
@@ -62,7 +62,7 @@ public final class GovernmentBodyRankingIncomePageModContentFactoryImpl extends 
 
 		final String pageId = getPageId(parameters);
 
-		panel.setCaption(NAME + "::" + GOVERNMENT_BODIES + parameters);
+		createPageHeader(panel, panelContent, "Government Body Income", "Income Details", "Explore detailed income information for government bodies.");
 
 		governmentBodyChartDataManager.createGovernmentBodyIncomeSummaryChart(panelContent);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyRankingPageVisitHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyRankingPageVisitHistoryPageModContentFactoryImpl.java
@@ -61,9 +61,9 @@ public final class GovernmentBodyRankingPageVisitHistoryPageModContentFactoryImp
 
 		final String pageId = getPageId(parameters);
 
-		getAdminChartDataManager().createApplicationActionEventPageModeDailySummaryChart(panelContent,NAME);
+		createPageHeader(panel, panelContent, "Government Body Ranking Page Visit History", "Page Visit History", "Track the visit history of government body ranking pages.");
 
-		panel.setCaption(NAME + "::" + PAGE_VISIT_HISTORY);
+		getAdminChartDataManager().createApplicationActionEventPageModeDailySummaryChart(panelContent,NAME);
 
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_GOVERNMENT_BODY_RANKING_VIEW, ApplicationEventGroup.USER,
 				NAME, parameters, pageId);


### PR DESCRIPTION
Update `createContent` methods in various classes to use `createPageHeader` instead of `panel.setCaption`.

* **GovernmentBodyExpenditurePageModContentFactoryImpl.java**
  - Replace `panel.setCaption` with `createPageHeader` in `createContent` method.
  - Add descriptive values for `createPageHeader` call.

* **GovernmentBodyHeadcountPageModContentFactoryImpl.java**
  - Replace `panel.setCaption` with `createPageHeader` in `createContent` method.
  - Add descriptive values for `createPageHeader` call.

* **GovernmentBodyIncomePageModContentFactoryImpl.java**
  - Replace `panel.setCaption` with `createPageHeader` in `createContent` method.
  - Add descriptive values for `createPageHeader` call.

* **GovernmentBodyPageVisitHistoryPageModContentFactoryImpl.java**
  - Replace `panel.setCaption` with `createPageHeader` in `createContent` method.
  - Add descriptive values for `createPageHeader` call.

* **GovernmentBodyRankingExpenditurePageModContentFactoryImpl.java**
  - Replace `panel.setCaption` with `createPageHeader` in `createContent` method.
  - Add descriptive values for `createPageHeader` call.

* **GovernmentBodyRankingHeadCountPageModContentFactoryImpl.java**
  - Replace `panel.setCaption` with `createPageHeader` in `createContent` method.
  - Add descriptive values for `createPageHeader` call.

* **GovernmentBodyRankingIncomePageModContentFactoryImpl.java**
  - Replace `panel.setCaption` with `createPageHeader` in `createContent` method.
  - Add descriptive values for `createPageHeader` call.

* **GovernmentBodyRankingPageVisitHistoryPageModContentFactoryImpl.java**
  - Replace `panel.setCaption` with `createPageHeader` in `createContent` method.
  - Add descriptive values for `createPageHeader` call.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/cia/pull/6810?shareId=bb62fa4b-e983-4c0b-9fee-2d36f8c94edc).