### PR TITLE
Fix page header in party page mode classes

### DIFF
--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyCommitteeBallotDecisionSummaryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyCommitteeBallotDecisionSummaryPageModContentFactoryImpl.java
@@ -94,7 +94,7 @@ public final class PartyCommitteeBallotDecisionSummaryPageModContentFactoryImpl
 
 		getPartyMenuItemFactory().createPartyMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, COMMITTEE_BALLOT_DECISION_SUMMARY);
+		createPageHeader(panel, panelContent, "Committee Ballot Decision Summary", "Ballot Decisions", "Review the summary of committee ballot decisions for the selected party.");
 
 		final DataContainer<ViewRiksdagenCommitteeBallotDecisionPartySummary, ViewRiksdagenCommitteeBallotDecisionPartyEmbeddedId> committeeBallotDecisionPartyDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenCommitteeBallotDecisionPartySummary.class);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyCommitteeRolesPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyCommitteeRolesPageModContentFactoryImpl.java
@@ -65,7 +65,7 @@ public final class PartyCommitteeRolesPageModContentFactoryImpl extends Abstract
 
 		getPartyMenuItemFactory().createPartyMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, COMMITTEE_ROLES);
+		createPageHeader(panel, panelContent, "Committee Roles", "Committee Members", "Explore the roles and members of various committees within the party.");
 
 		final DataContainer<ViewRiksdagenCommitteeRoleMember, String> committeeRoleMemberDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenCommitteeRoleMember.class);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyCurrentLeadersPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyCurrentLeadersPageModContentFactoryImpl.java
@@ -64,7 +64,7 @@ public final class PartyCurrentLeadersPageModContentFactoryImpl extends Abstract
 		final ViewRiksdagenParty viewRiksdagenParty = getItem(parameters);
 		getPartyMenuItemFactory().createPartyMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, CURRENT_LEADERS);
+		createPageHeader(panel, panelContent, "Current Leaders", "Party Leadership", "Meet the current leaders of the party and their roles.");
 
 		final DataContainer<ViewRiksdagenPartyRoleMember, String> partyRoleMemberDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenPartyRoleMember.class);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyCurrentMembersPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyCurrentMembersPageModContentFactoryImpl.java
@@ -78,7 +78,7 @@ public final class PartyCurrentMembersPageModContentFactoryImpl extends Abstract
 		final ViewRiksdagenParty viewRiksdagenParty = getItem(parameters);
 		getPartyMenuItemFactory().createPartyMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, CURRENT_MEMBERS);
+		createPageHeader(panel, panelContent, "Current Members", "Party Members", "Discover the current members of the party and their roles.");
 
 		final DataContainer<ViewRiksdagenPolitician, String> politicianDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenPolitician.class);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyDocumentHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyDocumentHistoryPageModContentFactoryImpl.java
@@ -8,7 +8,7 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
+ * distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -67,7 +67,7 @@ public final class PartyDocumentHistoryPageModContentFactoryImpl extends Abstrac
 		final ViewRiksdagenParty viewRiksdagenParty = getItem(parameters);
 		getPartyMenuItemFactory().createPartyMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, DOCUMENT_HISTORY);
+		createPageHeader(panel, panelContent, "Document History", "Historical Documents", "Explore the historical documents associated with the party.");
 
 		final DataContainer<ViewRiksdagenPoliticianDocument, String> politicianDocumentDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenPoliticianDocument.class);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyGovernmentRolesPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyGovernmentRolesPageModContentFactoryImpl.java
@@ -64,7 +64,7 @@ public final class PartyGovernmentRolesPageModContentFactoryImpl extends Abstrac
 		final ViewRiksdagenParty viewRiksdagenParty = getItem(parameters);
 		getPartyMenuItemFactory().createPartyMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, GOVERNMENT_ROLES);
+		createPageHeader(panel, panelContent, "Government Roles", "Government Members", "Explore the roles and members of the government within the party.");
 
 		final DataContainer<ViewRiksdagenGovermentRoleMember, String> govermentRoleMemberDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenGovermentRoleMember.class);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyLeaderHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyLeaderHistoryPageModContentFactoryImpl.java
@@ -65,7 +65,7 @@ public final class PartyLeaderHistoryPageModContentFactoryImpl extends AbstractP
 		final ViewRiksdagenParty viewRiksdagenParty = getItem(parameters);
 		getPartyMenuItemFactory().createPartyMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, LEADER_HISTORY);
+		createPageHeader(panel, panelContent, "Leader History", "Party Leaders", "Explore the history of party leaders and their roles.");
 
 		final DataContainer<ViewRiksdagenPartyRoleMember, String> partyRoleMemberDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenPartyRoleMember.class);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyMemberHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyMemberHistoryPageModContentFactoryImpl.java
@@ -78,7 +78,7 @@ public final class PartyMemberHistoryPageModContentFactoryImpl extends AbstractP
 		final ViewRiksdagenParty viewRiksdagenParty = getItem(parameters);
 		getPartyMenuItemFactory().createPartyMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, MEMBER_HISTORY);
+		createPageHeader(panel, panelContent, "Member History", "Party Members", "Explore the history of party members and their roles.");
 
 		final DataContainer<ViewRiksdagenPolitician, String> politicianDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenPolitician.class);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyPageVisitHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyPageVisitHistoryPageModContentFactoryImpl.java
@@ -53,6 +53,8 @@ public final class PartyPageVisitHistoryPageModContentFactoryImpl extends Abstra
 		final ViewRiksdagenParty viewRiksdagenParty = getItem(parameters);
 		getPartyMenuItemFactory().createPartyMenuBar(menuBar, pageId);
 
+		createPageHeader(panel, panelContent, "Page Visit History", "Visit History", "Review the history of page visits for the selected party.");
+
 		createPageVisitHistory(NAME, pageId, panelContent);
 
 		pageCompleted(parameters, panel, pageId, viewRiksdagenParty);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRankingAllPartiesChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRankingAllPartiesChartsPageModContentFactoryImpl.java
@@ -71,8 +71,10 @@ public final class PartyRankingAllPartiesChartsPageModContentFactoryImpl extends
 
 		final String pageId = getPageId(parameters);
 
-
 		getPartyRankingMenuItemFactory().createPartyRankingMenuBar(menuBar);
+
+		createPageHeader(panel, panelContent, "All Parties Charts", "Party Performance", "Analyze the performance of all political parties using various charts.");
+
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
@@ -80,7 +82,6 @@ public final class PartyRankingAllPartiesChartsPageModContentFactoryImpl extends
 
 		panelContent.addComponent(chartLayout);
 
-		panel.setCaption(NAME + "::" + CHARTS + parameters);
 
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_PARTY_RANKING_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRankingCurrentCommitteeChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRankingCurrentCommitteeChartsPageModContentFactoryImpl.java
@@ -71,8 +71,10 @@ public final class PartyRankingCurrentCommitteeChartsPageModContentFactoryImpl e
 
 		final String pageId = getPageId(parameters);
 
-
 		getPartyRankingMenuItemFactory().createPartyRankingMenuBar(menuBar);
+
+		createPageHeader(panel, panelContent, "Current Committee Charts", "Committee Performance", "Analyze the performance of current committees using various charts.");
+
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
@@ -80,7 +82,6 @@ public final class PartyRankingCurrentCommitteeChartsPageModContentFactoryImpl e
 
 		panelContent.addComponent(chartLayout);
 
-		panel.setCaption(NAME + "::" + CHARTS + parameters);
 
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_PARTY_RANKING_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRankingCurrentGovernmentChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRankingCurrentGovernmentChartsPageModContentFactoryImpl.java
@@ -73,6 +73,9 @@ public final class PartyRankingCurrentGovernmentChartsPageModContentFactoryImpl 
 
 
 		getPartyRankingMenuItemFactory().createPartyRankingMenuBar(menuBar);
+
+		createPageHeader(panel, panelContent, "Current Government Charts", "Government Performance", "Analyze the performance of the current government using various charts.");
+
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
@@ -80,7 +83,6 @@ public final class PartyRankingCurrentGovernmentChartsPageModContentFactoryImpl 
 
 		panelContent.addComponent(chartLayout);
 
-		panel.setCaption(NAME + "::" + CHARTS + parameters);
 
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_PARTY_RANKING_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRankingCurrentPartiesLeaderScoreboardPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRankingCurrentPartiesLeaderScoreboardPageModContentFactoryImpl.java
@@ -61,16 +61,15 @@ public final class PartyRankingCurrentPartiesLeaderScoreboardPageModContentFacto
 
 
 		getPartyRankingMenuItemFactory().createPartyRankingMenuBar(menuBar);
+
+		createPageHeader(panel, panelContent, "Current Party Leaders Scoreboard", "Leader Performance", "Evaluate the performance of current party leaders using a scoreboard.");
+
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
 
-
-
-
 		panelContent.addComponent(chartLayout);
 
-		panel.setCaption(NAME + "::" + CHARTS + parameters);
 
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_PARTY_RANKING_VIEW, ApplicationEventGroup.USER, NAME,
 				parameters, pageId);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRankingPageVisitHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRankingPageVisitHistoryPageModContentFactoryImpl.java
@@ -61,9 +61,9 @@ public final class PartyRankingPageVisitHistoryPageModContentFactoryImpl
 
 		final String pageId = getPageId(parameters);
 
-		getAdminChartDataManager().createApplicationActionEventPageModeDailySummaryChart(panelContent,NAME);
+		createPageHeader(panel, panelContent, "Page Visit History", "User Activity", "Track the history of page visits for party rankings.");
 
-		panel.setCaption(NAME + "::" + PAGE_VISIT_HISTORY);
+		getAdminChartDataManager().createApplicationActionEventPageModeDailySummaryChart(panelContent,NAME);
 
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_PARTY_RANKING_VIEW, ApplicationEventGroup.USER,
 				NAME, parameters, pageId);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRoleGhantPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRoleGhantPageModContentFactoryImpl.java
@@ -65,7 +65,7 @@ public final class PartyRoleGhantPageModContentFactoryImpl extends AbstractParty
 		final ViewRiksdagenParty viewRiksdagenParty = getItem(parameters);
 		getPartyMenuItemFactory().createPartyMenuBar(menuBar, pageId);
 
-		createPageHeader(panelContent, viewRiksdagenParty.getPartyName(), viewRiksdagenParty.getPartyId());
+		createPageHeader(panel, panelContent, viewRiksdagenParty.getPartyName(), viewRiksdagenParty.getPartyId(), ROLE_GHANT);
 
 		final DataContainer<ViewRiksdagenPartyRoleMember, String> partyRoleMemberDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenPartyRoleMember.class);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRoleGhantPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRoleGhantPageModContentFactoryImpl.java
@@ -65,7 +65,7 @@ public final class PartyRoleGhantPageModContentFactoryImpl extends AbstractParty
 		final ViewRiksdagenParty viewRiksdagenParty = getItem(parameters);
 		getPartyMenuItemFactory().createPartyMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, ROLE_GHANT);
+		createPageHeader(panelContent, viewRiksdagenParty.getPartyName(), viewRiksdagenParty.getPartyId());
 
 		final DataContainer<ViewRiksdagenPartyRoleMember, String> partyRoleMemberDataContainer = getApplicationManager()
 				.getDataContainer(ViewRiksdagenPartyRoleMember.class);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyVoteHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyVoteHistoryPageModContentFactoryImpl.java
@@ -85,7 +85,7 @@ public final class PartyVoteHistoryPageModContentFactoryImpl extends AbstractPar
 		final ViewRiksdagenParty viewRiksdagenParty = getItem(parameters);
 		getPartyMenuItemFactory().createPartyMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, VOTE_HISTORY);
+		createPageHeader(panel, panelContent, "Vote History", "Ballots", "Review the voting history for the selected party.");
 
 		getGridFactory().createBasicBeanItemNestedPropertiesGrid(panelContent,
 				ViewRiksdagenVoteDataBallotPartySummary.class,

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyWonDailySummaryChartPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyWonDailySummaryChartPageModContentFactoryImpl.java
@@ -62,7 +62,7 @@ public final class PartyWonDailySummaryChartPageModContentFactoryImpl extends Ab
 		final ViewRiksdagenParty viewRiksdagenParty = getItem(parameters);
 		getPartyMenuItemFactory().createPartyMenuBar(menuBar, pageId);
 
-		LabelFactory.createHeader2Label(panelContent, PARTY_WON_DAILY_SUMMARY_CHART);
+		createPageHeader(panelContent, "Party Won Daily Summary Chart", "Daily Summary", "Analyze the daily summary of party wins over time.");
 
 		chartDataManager.createPartyLineChart(panelContent, pageId);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyWonDailySummaryChartPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyWonDailySummaryChartPageModContentFactoryImpl.java
@@ -62,7 +62,7 @@ public final class PartyWonDailySummaryChartPageModContentFactoryImpl extends Ab
 		final ViewRiksdagenParty viewRiksdagenParty = getItem(parameters);
 		getPartyMenuItemFactory().createPartyMenuBar(menuBar, pageId);
 
-		createPageHeader(panelContent, "Party Won Daily Summary Chart", "Daily Summary", "Analyze the daily summary of party wins over time.");
+		createPageHeader(panel, panelContent, "Party Won Daily Summary Chart", "Daily Summary", "Analyze the daily summary of party wins over time.");
 
 		chartDataManager.createPartyLineChart(panelContent, pageId);
 


### PR DESCRIPTION
Update classes in `citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/*` to use `createPageHeader` with descriptive values after creating a menubar.

* **PartyCommitteeBallotDecisionSummaryPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader` after creating the menubar.
* **PartyCommitteeRolesPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader` after creating the menubar.
* **PartyCurrentLeadersPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader` after creating the menubar.
* **PartyCurrentMembersPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader` after creating the menubar.
* **PartyDocumentHistoryPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader` after creating the menubar.
* **PartyGovernmentRolesPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader` after creating the menubar.
* **PartyLeaderHistoryPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader` after creating the menubar.
* **PartyMemberHistoryPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader` after creating the menubar.
* **PartyPageVisitHistoryPageModContentFactoryImpl.java**
  - Add `createPageHeader` after creating the menubar.
* **PartyRankingAllPartiesChartsPageModContentFactoryImpl.java**
  - Add `createPageHeader` after creating the menubar.
* **PartyRankingCurrentCommitteeChartsPageModContentFactoryImpl.java**
  - Add `createPageHeader` after creating the menubar.
* **PartyRankingCurrentGovernmentChartsPageModContentFactoryImpl.java**
  - Add `createPageHeader` after creating the menubar.
* **PartyRankingCurrentPartiesLeaderScoreboardPageModContentFactoryImpl.java**
  - Add `createPageHeader` after creating the menubar.
* **PartyRankingPageVisitHistoryPageModContentFactoryImpl.java**
  - Add `createPageHeader` after creating the menubar.
* **PartyRoleGhantPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader` after creating the menubar.
* **PartyVoteHistoryPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader` after creating the menubar.
* **PartyWonDailySummaryChartPageModContentFactoryImpl.java**
  - Replace `LabelFactory.createHeader2Label` with `createPageHeader` after creating the menubar.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/cia/pull/6811?shareId=c899c542-4fa1-479a-b40c-c13f1ebc5219).