### PR TITLE
Fix Javadoc warnings for missing comments and descriptions

### DIFF
--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/CitizenIntelligenceAgencyHealthCheckServlet.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/CitizenIntelligenceAgencyHealthCheckServlet.java
@@ -41,6 +41,13 @@ public final class CitizenIntelligenceAgencyHealthCheckServlet extends HttpServl
 	/** The Constant TEXT_HTML. */
 	private static final String TEXT_HTML = "text/html";
 
+	/**
+	 * Default constructor for CitizenIntelligenceAgencyHealthCheckServlet.
+	 */
+	public CitizenIntelligenceAgencyHealthCheckServlet() {
+		// Default constructor
+	}
+
 	@Override
 	public void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
 		response.setContentType(TEXT_HTML);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/CitizenIntelligenceAgencySpringVaadinServlet.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/CitizenIntelligenceAgencySpringVaadinServlet.java
@@ -44,6 +44,13 @@ public final class CitizenIntelligenceAgencySpringVaadinServlet extends SpringVa
 	/** The Constant serialVersionUID. */
 	private static final long serialVersionUID = 1L;
 
+	/**
+	 * Default constructor for CitizenIntelligenceAgencySpringVaadinServlet.
+	 */
+	public CitizenIntelligenceAgencySpringVaadinServlet() {
+		// Default constructor
+	}
+
 	@Override
 	protected void service(final HttpServletRequest request, final HttpServletResponse response)
 			throws ServletException, IOException {

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/ResourceServlet.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/ResourceServlet.java
@@ -43,6 +43,13 @@ public class ResourceServlet extends DefaultServlet {
 	/** The Constant serialVersionUID. */
 	private static final long serialVersionUID = 1L;
 
+	/**
+	 * Default constructor for ResourceServlet.
+	 */
+	public ResourceServlet() {
+		// Default constructor
+	}
+
 	 @Override
 	  protected void service(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
 		 response.setHeader("Pragma", "cache");

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/VaadinSpringConfig.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/VaadinSpringConfig.java
@@ -31,4 +31,10 @@ import com.vaadin.spring.annotation.EnableVaadinNavigation;
 @EnableVaadinNavigation
 public class VaadinSpringConfig {
 
+    /**
+     * Default constructor for VaadinSpringConfig.
+     */
+    public VaadinSpringConfig() {
+        // Default constructor
+    }
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/action/ViewAction.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/action/ViewAction.java
@@ -101,6 +101,7 @@ public enum ViewAction {
 	/** The visit ministry view. */
 	VISIT_MINISTRY_VIEW,
 
+	/** The visit parliament ranking view. */
 	VISIT_PARLIAMENT_RANKING_VIEW,
 
 	/** The visit party ranking view. */
@@ -113,7 +114,10 @@ public enum ViewAction {
 	VISIT_POLITICIAN_RANKING_VIEW,
 
 	/** The visit politician view. */
-	VISIT_POLITICIAN_VIEW, VISIT_REGISTER,
+	VISIT_POLITICIAN_VIEW,
+
+	/** The visit register. */
+	VISIT_REGISTER,
 
 	/** The visit search view. */
 	VISIT_SEARCH_VIEW,

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/util/UserContextUtil.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/util/UserContextUtil.java
@@ -37,6 +37,13 @@ import com.vaadin.server.Page;
 public final class UserContextUtil {
 
 	/**
+	 * Default constructor for UserContextUtil.
+	 */
+	public UserContextUtil() {
+		// Default constructor
+	}
+
+	/**
 	 * Allow role in security context.
 	 *
 	 * @param role

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/util/WebBrowserUtil.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/util/WebBrowserUtil.java
@@ -44,6 +44,13 @@ public final class WebBrowserUtil {
 	public static final String X_FORWARDED_FOR = "X-Forwarded-For";
 
 	/**
+	 * Default constructor for WebBrowserUtil.
+	 */
+	public WebBrowserUtil() {
+		// Default constructor
+	}
+
+	/**
 	 * Gets the ip information.
 	 *
 	 * @param webBrowser

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/formfactory/impl/FormFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/formfactory/impl/FormFactoryImpl.java
@@ -76,6 +76,13 @@ public final class FormFactoryImpl implements FormFactory {
 	private static final int SIZE_FOR_GRID = 8;
 
 	/**
+	 * Default constructor for FormFactoryImpl.
+	 */
+	public FormFactoryImpl() {
+		// Default constructor
+	}
+
+	/**
 	 * Creates the display property converters.
 	 *
 	 * @param                     <T> the generic type

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/GovernmentBodyMenuItemFactory.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/GovernmentBodyMenuItemFactory.java
@@ -34,6 +34,7 @@ public interface GovernmentBodyMenuItemFactory {
 	 * @param pageId
 	 *            the page id
 	 * @param title
+	 *            the title of the menu item
 	 */
 	void createGovernmentBodyMenuBar(MenuBar menuBar, String pageId, String title);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/pagelinks/impl/PageLinkFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/pagelinks/impl/PageLinkFactoryImpl.java
@@ -66,6 +66,13 @@ public final class PageLinkFactoryImpl implements PageLinkFactory {
 	/** The Constant POLITICIAN. */
 	private static final String POLITICIAN = "Politician ";
 
+	/**
+	 * Default constructor for PageLinkFactoryImpl.
+	 */
+	public PageLinkFactoryImpl() {
+		// Default constructor
+	}
+
 	@Override
 	public Link addCommitteePageLink(final ViewRiksdagenCommittee data) {
 		final Link pageLink = new Link(COMMITTEE

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/pagemode/AbstractPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/pagemode/AbstractPageModContentFactoryImpl.java
@@ -141,6 +141,11 @@ public abstract class AbstractPageModContentFactoryImpl implements PageModeConte
 		return panelContent;
 	}
 
+	/**
+	 * Gets the admin chart data manager.
+	 *
+	 * @return the admin chart data manager
+	 */
 	protected final AdminChartDataManager getAdminChartDataManager() {
 		return adminChartDataManager;
 	}

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/paging/PagingUtilImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/paging/PagingUtilImpl.java
@@ -72,6 +72,13 @@ public final class PagingUtilImpl implements PagingUtil {
 	private PageLinkFactory pageLinkFactory;
 
 	/**
+	 * Default constructor for PagingUtilImpl.
+	 */
+	public PagingUtilImpl() {
+		// Default constructor
+	}
+
+	/**
 	 * Adds the paging link.
 	 *
 	 * @param label          the label

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/rows/RowUtil.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/rows/RowUtil.java
@@ -53,6 +53,13 @@ public final class RowUtil {
 	private static final String TITLE = "title";
 
 	/**
+	 * Default constructor for RowUtil.
+	 */
+	public RowUtil() {
+		// Default constructor
+	}
+
+	/**
 	 * Creates the grid layout.
 	 *
 	 * @param panelContent the panel content

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/sizing/ContentRatio.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/sizing/ContentRatio.java
@@ -50,4 +50,10 @@ public final class ContentRatio {
 	/** The Constant SMALL3. */
 	public static final float SMALL3 = 3;
 
+	/**
+	 * Default constructor for ContentRatio.
+	 */
+	public ContentRatio() {
+		// Default constructor
+	}
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/sizing/ContentSize.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/sizing/ContentSize.java
@@ -29,4 +29,10 @@ public final class ContentSize {
 	/** The Constant HALF_SIZE. */
 	public static final String HALF_SIZE = "50%";
 
+	/**
+	 * Default constructor for ContentSize.
+	 */
+	public ContentSize() {
+		// Default constructor
+	}
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/viewnames/AdminViews.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/viewnames/AdminViews.java
@@ -59,4 +59,10 @@ public final class AdminViews {
 	/** The Constant ADMIN_USERACCOUNT_VIEW_NAME. */
 	public static final String ADMIN_USERACCOUNT_VIEW_NAME = "adminuseraccount";
 
+	/**
+	 * Default constructor for AdminViews.
+	 */
+	public AdminViews() {
+		// Default constructor
+	}
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/viewnames/CommonsViews.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/viewnames/CommonsViews.java
@@ -29,4 +29,10 @@ public final class CommonsViews {
 	/** The Constant DASHBOARD_VIEW_NAME. */
 	public static final String DASHBOARD_VIEW_NAME = "dashboard";
 
+	/**
+	 * Default constructor for CommonsViews.
+	 */
+	public CommonsViews() {
+		// Default constructor
+	}
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/viewnames/UserViews.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/viewnames/UserViews.java
@@ -74,4 +74,10 @@ public final class UserViews {
 	/** The Constant USERHOME_VIEW_NAME. */
 	public static final String USERHOME_VIEW_NAME = "userhome";
 
+	/**
+	 * Default constructor for UserViews.
+	 */
+	public UserViews() {
+		// Default constructor
+	}
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/ballot/pagemode/AbstractBallotPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/ballot/pagemode/AbstractBallotPageModContentFactoryImpl.java
@@ -49,6 +49,11 @@ abstract class AbstractBallotPageModContentFactoryImpl extends AbstractItemPageM
 		super();
 	}
 
+	/**
+	 * Gets the ballot menu item factory.
+	 *
+	 * @return the ballot menu item factory
+	 */
 	protected final BallotMenuItemFactory getBallotMenuItemFactory() {
 		return ballotMenuItemFactory;
 	}

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/document/pagemode/AbstractDocumentPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/document/pagemode/AbstractDocumentPageModContentFactoryImpl.java
@@ -43,6 +43,11 @@ abstract class AbstractDocumentPageModContentFactoryImpl extends AbstractItemPag
 		super();
 	}
 
+	/**
+	 * Gets the document menu item factory.
+	 *
+	 * @return the document menu item factory
+	 */
 	protected final DocumentMenuItemFactory getDocumentMenuItemFactory() {
 		return documentMenuItemFactory;
 	}

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/document/pagemode/AbstractDocumentsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/document/pagemode/AbstractDocumentsPageModContentFactoryImpl.java
@@ -42,6 +42,11 @@ abstract class AbstractDocumentsPageModContentFactoryImpl extends AbstractBasicP
 		super();
 	}
 
+	/**
+	 * Gets the document menu item factory.
+	 *
+	 * @return the document menu item factory
+	 */
 	protected final DocumentMenuItemFactory getDocumentMenuItemFactory() {
 		return documentMenuItemFactory;
 	}

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/AbstractMinistryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/AbstractMinistryPageModContentFactoryImpl.java
@@ -48,6 +48,11 @@ abstract class AbstractMinistryPageModContentFactoryImpl extends AbstractItemPag
 		return getApplicationManager().getDataContainer(ViewRiksdagenMinistry.class).load(getPageId(parameters));
 	}
 
+	/**
+	 * Gets the ministry menu item factory.
+	 *
+	 * @return the ministry menu item factory
+	 */
 	protected final MinistryMenuItemFactory getMinistryMenuItemFactory() {
 		return ministryMenuItemFactory;
 	}

--- a/citizen-intelligence-agency/src/main/java/module-info.java
+++ b/citizen-intelligence-agency/src/main/java/module-info.java
@@ -1,3 +1,6 @@
+/**
+ * This module contains the main application code for the Citizen Intelligence Agency web application.
+ */
 open module com.hack23.cia.web {
 	exports com.hack23.cia.web.impl.ui.application;
 	exports com.hack23.cia.web.impl.ui.application.action;


### PR DESCRIPTION
Add Javadoc comments to address warnings for missing comments and descriptions.

* Add Javadoc comments for methods in `AbstractPageModContentFactoryImpl.java`, `AbstractBallotPageModContentFactoryImpl.java`, `AbstractDocumentPageModContentFactoryImpl.java`, `AbstractDocumentsPageModContentFactoryImpl.java`, `AbstractMinistryPageModContentFactoryImpl.java`.
* Add Javadoc comments for default constructors in `CitizenIntelligenceAgencyHealthCheckServlet.java`, `CitizenIntelligenceAgencySpringVaadinServlet.java`, `CommonsViews.java`, `ContentRatio.java`, `ContentSize.java`, `FormFactoryImpl.java`, `PageLinkFactoryImpl.java`, `PagingUtilImpl.java`, `ResourceServlet.java`, `RowUtil.java`, `UserContextUtil.java`, `UserViews.java`, `VaadinSpringConfig.java`, `WebBrowserUtil.java`.
* Add missing description for the `title` parameter in `GovernmentBodyMenuItemFactory.java`.
* Add Javadoc comments for constants `VISIT_PARLIAMENT_RANKING_VIEW` and `VISIT_POLITICIAN_VIEW` in `ViewAction.java`.
* Add a Javadoc comment in `module-info.java`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/cia?shareId=XXXX-XXXX-XXXX-XXXX).