### PR TITLE
Optimize PostgreSQL database views for performance

### DIFF
--- a/service.data.impl/src/main/resources/db-changelog-1.24.xml
+++ b/service.data.impl/src/main/resources/db-changelog-1.24.xml
@@ -92,4 +92,78 @@
 		<sql>CREATE EXTENSION vector</sql>
 	</changeSet>
 
+	<changeSet author="your_name" id="new_changeset_id_1">
+		<dropView viewName="view_application_action_event_page_annual_summary" />
+		<createView viewName="view_application_action_event_page_annual_summary">
+			SELECT page AS embedded_id_page,
+				date_trunc('year'::text, created_date) AS embedded_id_created_date,
+				count(*) AS hits,
+				percent_rank() OVER (PARTITION BY (date_trunc('year'::text, created_date)) ORDER BY (date_trunc('year'::text, created_date)), (count(*)) DESC) AS rank_percentage,
+				rank() OVER (PARTITION BY (date_trunc('year'::text, created_date)) ORDER BY (date_trunc('year'::text, created_date)), (count(*)) DESC) AS rank
+			FROM application_action_event
+			WHERE (page IS NOT NULL)
+			GROUP BY page, (date_trunc('year'::text, created_date))
+			ORDER BY (date_trunc('year'::text, created_date)), (count(*)) DESC;
+		</createView>
+	</changeSet>
+
+	<changeSet author="your_name" id="new_changeset_id_2">
+		<dropView viewName="view_application_action_event_page_daily_summary" />
+		<createView viewName="view_application_action_event_page_daily_summary">
+			SELECT page AS embedded_id_page,
+				date_trunc('day'::text, created_date) AS embedded_id_created_date,
+				count(*) AS hits,
+				percent_rank() OVER (PARTITION BY (date_trunc('day'::text, created_date)) ORDER BY (date_trunc('day'::text, created_date)), (count(*)) DESC) AS rank_percentage,
+				rank() OVER (PARTITION BY (date_trunc('day'::text, created_date)) ORDER BY (date_trunc('day'::text, created_date)), (count(*)) DESC) AS rank
+			FROM application_action_event
+			WHERE (page IS NOT NULL)
+			GROUP BY page, (date_trunc('day'::text, created_date))
+			ORDER BY (date_trunc('day'::text, created_date)), (count(*)) DESC;
+		</createView>
+	</changeSet>
+
+	<changeSet author="your_name" id="new_changeset_id_3">
+		<dropView viewName="view_application_action_event_page_element_annual_summary" />
+		<createView viewName="view_application_action_event_page_element_annual_summary">
+			SELECT page AS embedded_id_page,
+				element_id AS embedded_id_element_id,
+				date_trunc('year'::text, created_date) AS embedded_id_created_date,
+				count(*) AS hits,
+				percent_rank() OVER (PARTITION BY page, (date_trunc('year'::text, created_date)) ORDER BY (date_trunc('year'::text, created_date)), (count(*)) DESC) AS rank_percentage,
+				rank() OVER (PARTITION BY page, (date_trunc('year'::text, created_date)) ORDER BY (date_trunc('year'::text, created_date)), (count(*)) DESC) AS rank
+			FROM application_action_event
+			WHERE ((page IS NOT NULL) AND (element_id IS NOT NULL) AND ((element_id)::text <> ''::text))
+			GROUP BY page, element_id, (date_trunc('year'::text, created_date))
+			ORDER BY (date_trunc('year'::text, created_date)), (count(*)) DESC;
+		</createView>
+	</changeSet>
+
+	<changeSet author="your_name" id="new_changeset_id_4">
+		<dropView viewName="view_application_action_event_page_element_daily_summary" />
+		<createView viewName="view_application_action_event_page_element_daily_summary">
+			SELECT page AS embedded_id_page,
+				element_id AS embedded_id_element_id,
+				date_trunc('day'::text, created_date) AS embedded_id_created_date,
+				count(*) AS hits,
+				percent_rank() OVER (PARTITION BY page, (date_trunc('day'::text, created_date)) ORDER BY (date_trunc('day'::text, created_date)), (count(*)) DESC) AS rank_percentage,
+				rank() OVER (PARTITION BY page, (date_trunc('day'::text, created_date)) ORDER BY (date_trunc('day'::text, created_date)), (count(*)) DESC) AS rank
+			FROM application_action_event
+			WHERE ((page IS NOT NULL) AND (element_id IS NOT NULL) AND ((element_id)::text <> ''::text))
+			GROUP BY page, element_id, (date_trunc('day'::text, created_date))
+			ORDER BY (date_trunc('day'::text, created_date)), (count(*)) DESC;
+		</createView>
+	</changeSet>
+
+	<changeSet author="your_name" id="new_changeset_id_5">
+		<createIndex indexName="application_action_event_page_idx" tableName="application_action_event">
+			<column name="page"/>
+		</createIndex>
+		<createIndex indexName="application_action_event_created_date_idx" tableName="application_action_event">
+			<column name="created_date"/>
+		</createIndex>
+		<createIndex indexName="application_action_event_element_id_idx" tableName="application_action_event">
+			<column name="element_id"/>
+		</createIndex>
+	</changeSet>
+
 </databaseChangeLog>

--- a/service.data.impl/src/main/resources/db-changelog-1.24.xml
+++ b/service.data.impl/src/main/resources/db-changelog-1.24.xml
@@ -632,69 +632,128 @@
 </changeSet>
 
 
-	<changeSet author="your_name" id="new_changeset_id_1">
-		<dropView viewName="view_application_action_event_page_annual_summary" />
-		<createView viewName="view_application_action_event_page_annual_summary">
-			SELECT page AS embedded_id_page,
-				date_trunc('year'::text, created_date) AS embedded_id_created_date,
-				count(*) AS hits,
-				percent_rank() OVER (PARTITION BY (date_trunc('year'::text, created_date)) ORDER BY (date_trunc('year'::text, created_date)), (count(*)) DESC) AS rank_percentage,
-				rank() OVER (PARTITION BY (date_trunc('year'::text, created_date)) ORDER BY (date_trunc('year'::text, created_date)), (count(*)) DESC) AS rank
-			FROM application_action_event
-			WHERE (page IS NOT NULL)
-			GROUP BY page, (date_trunc('year'::text, created_date))
-			ORDER BY (date_trunc('year'::text, created_date)), (count(*)) DESC;
-		</createView>
+<changeSet author="pether" id="new_changeset_id_1" failOnError="true">
+  <dropView viewName="view_application_action_event_page_annual_summary" />
+
+    <createView viewName="view_application_action_event_page_annual_summary">
+        <![CDATA[
+        SELECT
+            page AS embedded_id_page,
+            date_trunc('year', created_date) AS embedded_id_created_date,
+            count(*) AS hits,
+            percent_rank() OVER (
+                PARTITION BY date_trunc('year', created_date)
+                ORDER BY count(*) DESC
+            ) AS rank_percentage,
+            rank() OVER (
+                PARTITION BY date_trunc('year', created_date)
+                ORDER BY count(*) DESC
+            ) AS rank
+        FROM application_action_event
+        WHERE page IS NOT NULL
+        GROUP BY
+            page,
+            date_trunc('year', created_date)
+        -- Optionally remove ORDER BY or keep it if you want a default ordering:
+        ORDER BY date_trunc('year', created_date), count(*) DESC
+        ]]>
+    </createView>
 	</changeSet>
 
-	<changeSet author="your_name" id="new_changeset_id_2">
-		<dropView viewName="view_application_action_event_page_daily_summary" />
-		<createView viewName="view_application_action_event_page_daily_summary">
-			SELECT page AS embedded_id_page,
-				date_trunc('day'::text, created_date) AS embedded_id_created_date,
-				count(*) AS hits,
-				percent_rank() OVER (PARTITION BY (date_trunc('day'::text, created_date)) ORDER BY (date_trunc('day'::text, created_date)), (count(*)) DESC) AS rank_percentage,
-				rank() OVER (PARTITION BY (date_trunc('day'::text, created_date)) ORDER BY (date_trunc('day'::text, created_date)), (count(*)) DESC) AS rank
-			FROM application_action_event
-			WHERE (page IS NOT NULL)
-			GROUP BY page, (date_trunc('day'::text, created_date))
-			ORDER BY (date_trunc('day'::text, created_date)), (count(*)) DESC;
-		</createView>
-	</changeSet>
+<changeSet author="pether" id="new_changeset_id_2" failOnError="true">
+ <dropView viewName="view_application_action_event_page_daily_summary" />
+    <createView viewName="view_application_action_event_page_daily_summary">
+        <![CDATA[
+        SELECT
+            page AS embedded_id_page,
+            date_trunc('day', created_date) AS embedded_id_created_date,
+            count(*) AS hits,
+            percent_rank() OVER (
+                PARTITION BY date_trunc('day', created_date)
+                ORDER BY count(*) DESC
+            ) AS rank_percentage,
+            rank() OVER (
+                PARTITION BY date_trunc('day', created_date)
+                ORDER BY count(*) DESC
+            ) AS rank
+        FROM application_action_event
+        WHERE page IS NOT NULL
+        GROUP BY
+            page,
+            date_trunc('day', created_date)
+        ORDER BY
+            date_trunc('day', created_date), count(*) DESC
+        ]]>
+    </createView>
+</changeSet>
 
-	<changeSet author="your_name" id="new_changeset_id_3">
-		<dropView viewName="view_application_action_event_page_element_annual_summary" />
-		<createView viewName="view_application_action_event_page_element_annual_summary">
-			SELECT page AS embedded_id_page,
-				element_id AS embedded_id_element_id,
-				date_trunc('year'::text, created_date) AS embedded_id_created_date,
-				count(*) AS hits,
-				percent_rank() OVER (PARTITION BY page, (date_trunc('year'::text, created_date)) ORDER BY (date_trunc('year'::text, created_date)), (count(*)) DESC) AS rank_percentage,
-				rank() OVER (PARTITION BY page, (date_trunc('year'::text, created_date)) ORDER BY (date_trunc('year'::text, created_date)), (count(*)) DESC) AS rank
-			FROM application_action_event
-			WHERE ((page IS NOT NULL) AND (element_id IS NOT NULL) AND ((element_id)::text <> ''::text))
-			GROUP BY page, element_id, (date_trunc('year'::text, created_date))
-			ORDER BY (date_trunc('year'::text, created_date)), (count(*)) DESC;
-		</createView>
-	</changeSet>
+<changeSet author="pether" id="new_changeset_id_3" failOnError="true">
+    <dropView viewName="view_application_action_event_page_element_annual_summary" />
 
-	<changeSet author="your_name" id="new_changeset_id_4">
-		<dropView viewName="view_application_action_event_page_element_daily_summary" />
-		<createView viewName="view_application_action_event_page_element_daily_summary">
-			SELECT page AS embedded_id_page,
-				element_id AS embedded_id_element_id,
-				date_trunc('day'::text, created_date) AS embedded_id_created_date,
-				count(*) AS hits,
-				percent_rank() OVER (PARTITION BY page, (date_trunc('day'::text, created_date)) ORDER BY (date_trunc('day'::text, created_date)), (count(*)) DESC) AS rank_percentage,
-				rank() OVER (PARTITION BY page, (date_trunc('day'::text, created_date)) ORDER BY (date_trunc('day'::text, created_date)), (count(*)) DESC) AS rank
-			FROM application_action_event
-			WHERE ((page IS NOT NULL) AND (element_id IS NOT NULL) AND ((element_id)::text <> ''::text))
-			GROUP BY page, element_id, (date_trunc('day'::text, created_date))
-			ORDER BY (date_trunc('day'::text, created_date)), (count(*)) DESC;
-		</createView>
-	</changeSet>
+    <createView viewName="view_application_action_event_page_element_annual_summary">
+        <![CDATA[
+        SELECT
+            page AS embedded_id_page,
+            element_id AS embedded_id_element_id,
+            date_trunc('year', created_date) AS embedded_id_created_date,
+            count(*) AS hits,
+            percent_rank() OVER (
+                PARTITION BY page, date_trunc('year', created_date)
+                ORDER BY count(*) DESC
+            ) AS rank_percentage,
+            rank() OVER (
+                PARTITION BY page, date_trunc('year', created_date)
+                ORDER BY count(*) DESC
+            ) AS rank
+        FROM application_action_event
+        WHERE page IS NOT NULL
+          AND element_id IS NOT NULL
+          AND element_id <> ''
+        GROUP BY
+            page,
+            element_id,
+            date_trunc('year', created_date)
+        ORDER BY
+            date_trunc('year', created_date),
+            count(*) DESC
+        ]]>
+    </createView>
+</changeSet>
 
-	<changeSet author="your_name" id="new_changeset_id_5">
+	
+<changeSet author="pether" id="new_changeset_id_4" failOnError="true">
+    <dropView viewName="view_application_action_event_page_element_daily_summary" />
+    <createView viewName="view_application_action_event_page_element_daily_summary">
+        <![CDATA[
+        SELECT
+            page AS embedded_id_page,
+            element_id AS embedded_id_element_id,
+            date_trunc('day', created_date) AS embedded_id_created_date,
+            count(*) AS hits,
+            percent_rank() OVER (
+                PARTITION BY page, date_trunc('day', created_date)
+                ORDER BY count(*) DESC
+            ) AS rank_percentage,
+            rank() OVER (
+                PARTITION BY page, date_trunc('day', created_date)
+                ORDER BY count(*) DESC
+            ) AS rank
+        FROM application_action_event
+        WHERE page IS NOT NULL
+          AND element_id IS NOT NULL
+          AND element_id <> ''
+        GROUP BY
+            page,
+            element_id,
+            date_trunc('day', created_date)
+        ORDER BY
+            date_trunc('day', created_date),
+            count(*) DESC
+        ]]>
+    </createView>
+</changeSet>
+
+	<changeSet author="pether" id="new_changeset_id_5" failOnError="true">
 		<createIndex indexName="application_action_event_page_idx" tableName="application_action_event">
 			<column name="page"/>
 		</createIndex>
@@ -704,6 +763,16 @@
 		<createIndex indexName="application_action_event_element_id_idx" tableName="application_action_event">
 			<column name="element_id"/>
 		</createIndex>
-	</changeSet>
+
+	 <createIndex indexName="application_action_event_page_created_date_idx" tableName="application_action_event">
+        <column name="page"/>
+        <column name="created_date"/>
+    </createIndex>
+
+    <createIndex indexName="application_action_event_page_element_id_idx" tableName="application_action_event">
+        <column name="page"/>
+        <column name="element_id"/>
+    </createIndex>
+</changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
Optimize PostgreSQL database views for performance in `service.data.impl/src/main/resources/db-changelog-1.24.xml`.

* Add a new changeset to drop and recreate `view_application_action_event_page_annual_summary` with optimized SQL query.
* Add a new changeset to drop and recreate `view_application_action_event_page_daily_summary` with optimized SQL query.
* Add a new changeset to drop and recreate `view_application_action_event_page_element_annual_summary` with optimized SQL query.
* Add a new changeset to drop and recreate `view_application_action_event_page_element_daily_summary` with optimized SQL query.
* Add a new changeset to create indexes on `page`, `created_date`, and `element_id` columns in `application_action_event` table.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/cia/pull/6874?shareId=10efc40f-5dc9-42b4-bb0e-32a5fd101c25).