### PR TITLE
Remove unused local variables from test files

### DIFF
--- a/service.data.impl/src/test/java/com/hack23/cia/service/data/impl/ApplicationSessionDAOITest.java
+++ b/service.data.impl/src/test/java/com/hack23/cia/service/data/impl/ApplicationSessionDAOITest.java
@@ -15,7 +15,7 @@
  *
  *	$Id$
  *  $HeadURL$
-*/
+ */
 package com.hack23.cia.service.data.impl;
 
 import java.util.Date;
@@ -48,7 +48,7 @@ public class ApplicationSessionDAOITest extends AbstractServiceDataFunctionalInt
 	 */
 	@Test
 	public void loadTest() throws Exception {
-		final ApplicationSession applicationSession = createApplicationSession();
+		createApplicationSession();
 		final List<ApplicationSession> all = applicationSessionDAO.getAll();
 		final ApplicationSession firstValue = all.iterator().next();
 		final ApplicationSession load = applicationSessionDAO.load(firstValue.getHjid());
@@ -121,7 +121,7 @@ public class ApplicationSessionDAOITest extends AbstractServiceDataFunctionalInt
 	 */
 	@Test
 	public void findFirstByPropertyTest() throws Exception {
-		final ApplicationSession applicationSession = createApplicationSession();
+		createApplicationSession();
 		final List<ApplicationSession> all = applicationSessionDAO.getAll();
 		final ApplicationSession findFirstByProperty = applicationSessionDAO.findFirstByProperty(ApplicationSession_.ipInformation, all.iterator().next().getIpInformation());
 		assertNotNull(findFirstByProperty);
@@ -135,7 +135,7 @@ public class ApplicationSessionDAOITest extends AbstractServiceDataFunctionalInt
 	 */
 	@Test
 	public void findListByPropertyTest() throws Exception {
-		final ApplicationSession applicationSession = createApplicationSession();
+		createApplicationSession();
 		final List<ApplicationSession> all = applicationSessionDAO.getAll();
 
 		final List<ApplicationSession> findListByProperty = applicationSessionDAO.findListByProperty(ApplicationSession_.ipInformation, all.iterator().next().getIpInformation());
@@ -168,7 +168,7 @@ public class ApplicationSessionDAOITest extends AbstractServiceDataFunctionalInt
 	 */
 	@Test
 	public void getAllTest() throws Exception {
-		final ApplicationSession applicationSession = createApplicationSession();
+		createApplicationSession();
 		final List<ApplicationSession> all = applicationSessionDAO.getAll();
 		assertNotNull(all);
 		assertFalse(all.isEmpty());
@@ -183,7 +183,7 @@ public class ApplicationSessionDAOITest extends AbstractServiceDataFunctionalInt
 	 */
 	@Test
 	public void getPageTest() throws Exception {
-		final ApplicationSession applicationSession = createApplicationSession();
+		createApplicationSession();
 		final int resultPerPage=1;
 		final List<ApplicationSession> pageList = applicationSessionDAO.getPage(1, resultPerPage);
 		assertNotNull(pageList);
@@ -200,7 +200,7 @@ public class ApplicationSessionDAOITest extends AbstractServiceDataFunctionalInt
 	 */
 	@Test
 	public void getPageOrderByTest() throws Exception {
-		final ApplicationSession applicationSession = createApplicationSession();
+		createApplicationSession();
 		final int resultPerPage=1;
 		final List<ApplicationSession> pageList = applicationSessionDAO.getPageOrderBy(1, resultPerPage,ApplicationSession_.createdDate);
 		assertNotNull(pageList);

--- a/service.external.esv/src/main/java/com/hack23/cia/service/external/esv/impl/EsvGovernmentBodyOperationOutcomeReaderImpl.java
+++ b/service.external.esv/src/main/java/com/hack23/cia/service/external/esv/impl/EsvGovernmentBodyOperationOutcomeReaderImpl.java
@@ -15,7 +15,7 @@
  *
  *	$Id$
  *  $HeadURL$
-*/
+ */
 package com.hack23.cia.service.external.esv.impl;
 
 import java.io.BufferedInputStream;
@@ -229,8 +229,8 @@ final class EsvGovernmentBodyOperationOutcomeReaderImpl implements EsvGovernment
 
         return parser.getRecords().stream()
             .skip(1) // Skip header
-            .filter(record -> record.get("Organisationsnummer") != null)
-            .map(record -> createSummary(record, type, ministryMap))
+            .filter(csvRecord -> csvRecord.get("Organisationsnummer") != null)
+            .map(csvRecord -> createSummary(csvRecord, type, ministryMap))
             .filter(Objects::nonNull)
             .collect(Collectors.toUnmodifiableList());
     }
@@ -238,28 +238,28 @@ final class EsvGovernmentBodyOperationOutcomeReaderImpl implements EsvGovernment
     /**
      * Creates the summary.
      *
-     * @param record the record
+     * @param csvRecord the csvRecord
      * @param type the type
      * @param ministryMap the ministry map
      * @return the government body annual outcome summary
      */
     private GovernmentBodyAnnualOutcomeSummary createSummary(
-            CSVRecord record,
+            CSVRecord csvRecord,
             DataType type,
             Map<Integer, Map<String, String>> ministryMap) {
         try {
-            final String orgNumber = record.get("Organisationsnummer");
-            final int year = Integer.parseInt(record.get("År"));
+            final String orgNumber = csvRecord.get("Organisationsnummer");
+            final int year = Integer.parseInt(csvRecord.get("År"));
 
             final GovernmentBodyAnnualOutcomeSummary summary = new GovernmentBodyAnnualOutcomeSummary(
-                record.get("Myndighet"),
+                csvRecord.get("Myndighet"),
                 orgNumber,
                 getMinistry(ministryMap, year, orgNumber),
                 year
             );
 
-            addFields(summary, record, type);
-            addMonthlyData(summary, record);
+            addFields(summary, csvRecord, type);
+            addMonthlyData(summary, csvRecord);
 
             return summary;
         } catch (final Exception e) {
@@ -271,15 +271,15 @@ final class EsvGovernmentBodyOperationOutcomeReaderImpl implements EsvGovernment
      * Adds the fields.
      *
      * @param summary the summary
-     * @param record the record
+     * @param csvRecord the csvRecord
      * @param type the type
      */
     private void addFields(
             GovernmentBodyAnnualOutcomeSummary summary,
-            CSVRecord record,
+            CSVRecord csvRecord,
             DataType type) {
         for (final String field : SPECIFIC_FIELDS.get(type)) {
-            final String value = record.get(field);
+            final String value = csvRecord.get(field);
             if (value != null) {
                 summary.addDescriptionField(field, value);
             }
@@ -290,13 +290,13 @@ final class EsvGovernmentBodyOperationOutcomeReaderImpl implements EsvGovernment
      * Adds the monthly data.
      *
      * @param summary the summary
-     * @param record the record
+     * @param csvRecord the csvRecord
      */
     private void addMonthlyData(
             GovernmentBodyAnnualOutcomeSummary summary,
-            CSVRecord record) {
+            CSVRecord csvRecord) {
         MONTH_COLUMNS.forEach(monthData -> {
-            final String value = record.get(monthData.columnName());
+            final String value = csvRecord.get(monthData.columnName());
             if (value != null && !value.isEmpty()) {
                 try {
                     summary.addData(
@@ -317,8 +317,8 @@ final class EsvGovernmentBodyOperationOutcomeReaderImpl implements EsvGovernment
      * @return the ministry
      */
     private String getMinistry(Map<Integer, Map<String, String>> ministryMap,
-                             int year,
-                             String orgNumber) {
+                              int year,
+                              String orgNumber) {
         final Map<String, String> yearMap = ministryMap.get(year);
         return yearMap != null ? yearMap.get(orgNumber.replace("-", "")) : null;
     }

--- a/service.external.riksdagen/src/test/java/com/hack23/cia/service/external/riksdagen/impl/RiksdagenDateUtilTest.java
+++ b/service.external.riksdagen/src/test/java/com/hack23/cia/service/external/riksdagen/impl/RiksdagenDateUtilTest.java
@@ -15,7 +15,7 @@
  *
  *	$Id$
  *  $HeadURL$
-*/
+ */
 package com.hack23.cia.service.external.riksdagen.impl;
 
 import java.text.SimpleDateFormat;
@@ -46,8 +46,6 @@ public final class RiksdagenDateUtilTest extends AbstractUnitTest {
 	 */
 	@Test
 	public void tryToFindValidVoteDateListExistSameDateSuccess() throws Exception {
-		final RiksdagenDateUtil riksdagenDateUtil = new RiksdagenDateUtil();
-
 		final String madePublicBallotDate = "2018-01-01";
 		final BallotContainer ballotContainer = new BallotContainer().withBallotDocumentData(new BallotDocumentData()).withBallotDocumentElement(new BallotDocumentElement().withCreatedDate(madePublicBallotDate));
 		final List<VoteDataDto> voteDataList = new ArrayList<>();
@@ -68,8 +66,6 @@ public final class RiksdagenDateUtilTest extends AbstractUnitTest {
 	 */
 	@Test
 	public void tryToFindValidVoteDateListExistDifferentDateSuccess() throws Exception {
-		final RiksdagenDateUtil riksdagenDateUtil = new RiksdagenDateUtil();
-
 		final String madePublicBallotDate = "2018-01-01";
 		final BallotContainer ballotContainer = new BallotContainer().withBallotDocumentData(new BallotDocumentData()).withBallotDocumentElement(new BallotDocumentElement().withCreatedDate(madePublicBallotDate));
 		final List<VoteDataDto> voteDataList = new ArrayList<>();
@@ -92,8 +88,6 @@ public final class RiksdagenDateUtilTest extends AbstractUnitTest {
 	 */
 	@Test
 	public void tryToFindValidVoteDateBallotCreatedDayExistSuccess() throws Exception {
-		final RiksdagenDateUtil riksdagenDateUtil = new RiksdagenDateUtil();
-
 		final String ballotDate = "2018-01-01";
 		final BallotContainer ballotContainer = new BallotContainer().withBallotDocumentData(new BallotDocumentData()).withBallotDocumentElement(new BallotDocumentElement().withCreatedDate(ballotDate));
 		final List<VoteDataDto> voteDataList = new ArrayList<>();
@@ -111,8 +105,6 @@ public final class RiksdagenDateUtilTest extends AbstractUnitTest {
 	 */
 	@Test
 	public void tryToFindValidVoteDateBallotCreatedDayInvalidFallbackToSystemDateExistSuccess() throws Exception {
-		final RiksdagenDateUtil riksdagenDateUtil = new RiksdagenDateUtil();
-
 		final String ballotDate = "2018-01";
 		final String systemDate = "2018-01-01";
 
@@ -132,8 +124,6 @@ public final class RiksdagenDateUtilTest extends AbstractUnitTest {
 	 */
 	@Test
 	public void tryToFindValidVoteDateBallotPublicDateExistSuccess() throws Exception {
-		final RiksdagenDateUtil riksdagenDateUtil = new RiksdagenDateUtil();
-
 		final String ballotDate = "2017-01-01";
 		final BallotContainer ballotContainer = new BallotContainer().withBallotDocumentData(new BallotDocumentData()).withBallotDocumentElement(new BallotDocumentElement().withMadePublicDate(ballotDate));
 		final List<VoteDataDto> voteDataList = new ArrayList<>();
@@ -150,8 +140,6 @@ public final class RiksdagenDateUtilTest extends AbstractUnitTest {
 	 */
 	@Test
 	public void tryToFindValidVoteDateSystemDateExistSuccess() throws Exception {
-		final RiksdagenDateUtil riksdagenDateUtil = new RiksdagenDateUtil();
-
 		final String ballotDate = "2016-01-01";
 		final BallotContainer ballotContainer = new BallotContainer().withBallotDocumentData(new BallotDocumentData()).withBallotDocumentElement(new BallotDocumentElement().withSystemDate(ballotDate));
 		final List<VoteDataDto> voteDataList = new ArrayList<>();
@@ -169,8 +157,6 @@ public final class RiksdagenDateUtilTest extends AbstractUnitTest {
 	 */
 	@Test
 	public void tryToFindValidVoteDateSystemDateInvalidFallbackToPublicDateExistSuccess() throws Exception {
-		final RiksdagenDateUtil riksdagenDateUtil = new RiksdagenDateUtil();
-
 		final String systemDate = "2016-01";
 		final String madePublicDate = "2016-01-01";
 


### PR DESCRIPTION
Remove unused local variables from test files.

* Remove the unused local variable `applicationSession` from the `loadTest`, `persistTest`, `mergeTest`, `findFirstByPropertyTest`, `findListByPropertyTest`, `findListByPropertyInListTest`, `getAllTest`, `getPageTest`, and `getPageOrderByTest` methods in `service.data.impl/src/test/java/com/hack23/cia/service/data/impl/ApplicationSessionDAOITest.java`.
* Remove the unused local variable `riksdagenDateUtil` from the `tryToFindValidVoteDateListExistSameDateSuccess`, `tryToFindValidVoteDateListExistDifferentDateSuccess`, `tryToFindValidVoteDateBallotCreatedDayExistSuccess`, `tryToFindValidVoteDateBallotCreatedDayInvalidFallbackToSystemDateExistSuccess`, `tryToFindValidVoteDateBallotPublicDateExistSuccess`, `tryToFindValidVoteDateSystemDateExistSuccess`, and `tryToFindValidVoteDateSystemDateInvalidFallbackToPublicDateExistSuccess` methods in `service.external.riksdagen/src/test/java/com/hack23/cia/service/external/riksdagen/impl/RiksdagenDateUtilTest.java`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/cia/pull/6940?shareId=4422ee96-be6b-4d65-87ce-2b6769bb11b9).