### PR TITLE
Refactor common party leader logic into utility class

### DIFF
--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/util/PartyLeaderUtil.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/util/PartyLeaderUtil.java
@@ -5,8 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.hack23.cia.model.internal.application.data.impl.ViewRiksdagenPartyRoleMember;
-import com.hack23.cia.model.internal.application.data.impl.ViewRiksdagenPartyRoleMember_;
+import com.hack23.cia.model.internal.application.data.party.impl.ViewRiksdagenPartyRoleMember;
+import com.hack23.cia.model.internal.application.data.party.impl.ViewRiksdagenPartyRoleMember_;
 import com.hack23.cia.service.api.DataContainer;
 import com.hack23.cia.service.api.ApplicationManager;
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/util/PartyLeaderUtil.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/util/PartyLeaderUtil.java
@@ -10,12 +10,25 @@ import com.hack23.cia.model.internal.application.data.impl.ViewRiksdagenPartyRol
 import com.hack23.cia.service.api.DataContainer;
 import com.hack23.cia.service.api.ApplicationManager;
 
+/**
+ * Utility class for handling party leader related operations.
+ */
 public final class PartyLeaderUtil {
+
+    private static final String ROLE_CODE_PARTILEDARE = "Partiledare";
+    private static final Object[] ACTIVE_PERSON_ID = new Object[] { Boolean.TRUE };
 
     private PartyLeaderUtil() {
         // Utility class, no instantiation
     }
 
+    /**
+     * Checks if a person is a party leader.
+     *
+     * @param applicationManager the application manager
+     * @param personId the person id
+     * @return true, if the person is a party leader
+     */
     public static boolean isPartyLeader(ApplicationManager applicationManager, String personId) {
         final DataContainer<ViewRiksdagenPartyRoleMember, String> container = 
             applicationManager.getDataContainer(ViewRiksdagenPartyRoleMember.class);
@@ -26,9 +39,16 @@ public final class PartyLeaderUtil {
 
         return roles.stream()
                 .anyMatch(r -> r.getRoleCode() != null 
-                    && "Partiledare".equalsIgnoreCase(r.getRoleCode().trim()));
+                    && ROLE_CODE_PARTILEDARE.equalsIgnoreCase(r.getRoleCode().trim()));
     }
 
+    /**
+     * Fetches the party leader role for a person.
+     *
+     * @param applicationManager the application manager
+     * @param personId the person id
+     * @return the party leader role, or null if not found
+     */
     public static ViewRiksdagenPartyRoleMember getPartyLeaderRole(ApplicationManager applicationManager, String personId) {
         final DataContainer<ViewRiksdagenPartyRoleMember, String> container = 
             applicationManager.getDataContainer(ViewRiksdagenPartyRoleMember.class);
@@ -39,11 +59,18 @@ public final class PartyLeaderUtil {
 
         return roles.stream()
                 .filter(r -> r.getRoleCode() != null 
-                    && "Partiledare".equalsIgnoreCase(r.getRoleCode().trim()))
+                    && ROLE_CODE_PARTILEDARE.equalsIgnoreCase(r.getRoleCode().trim()))
                 .findFirst()
                 .orElse(null);
     }
 
+    /**
+     * Computes party leaders for a list of person IDs.
+     *
+     * @param applicationManager the application manager
+     * @param personIds the person ids
+     * @return a map of person ids to boolean indicating if they are party leaders
+     */
     public static Map<String, Boolean> computePartyLeaders(ApplicationManager applicationManager, Iterable<String> personIds) {
         final DataContainer<ViewRiksdagenPartyRoleMember, String> container = 
             applicationManager.getDataContainer(ViewRiksdagenPartyRoleMember.class);
@@ -57,7 +84,7 @@ public final class PartyLeaderUtil {
 
             final boolean isLeader = roles.stream()
                     .anyMatch(r -> r.getRoleCode() != null 
-                        && "Partiledare".equalsIgnoreCase(r.getRoleCode().trim()));
+                        && ROLE_CODE_PARTILEDARE.equalsIgnoreCase(r.getRoleCode().trim()));
             result.put(personId, isLeader);
         }
         return result;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/util/PartyLeaderUtil.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/util/PartyLeaderUtil.java
@@ -1,0 +1,65 @@
+package com.hack23.cia.web.impl.ui.application.util;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.hack23.cia.model.internal.application.data.impl.ViewRiksdagenPartyRoleMember;
+import com.hack23.cia.model.internal.application.data.impl.ViewRiksdagenPartyRoleMember_;
+import com.hack23.cia.service.api.DataContainer;
+import com.hack23.cia.service.api.ApplicationManager;
+
+public final class PartyLeaderUtil {
+
+    private PartyLeaderUtil() {
+        // Utility class, no instantiation
+    }
+
+    public static boolean isPartyLeader(ApplicationManager applicationManager, String personId) {
+        final DataContainer<ViewRiksdagenPartyRoleMember, String> container = 
+            applicationManager.getDataContainer(ViewRiksdagenPartyRoleMember.class);
+        final List<ViewRiksdagenPartyRoleMember> roles =
+            container.findListByProperty(new Object[] { personId, Boolean.TRUE },
+                    ViewRiksdagenPartyRoleMember_.personId,
+                    ViewRiksdagenPartyRoleMember_.active);
+
+        return roles.stream()
+                .anyMatch(r -> r.getRoleCode() != null 
+                    && "Partiledare".equalsIgnoreCase(r.getRoleCode().trim()));
+    }
+
+    public static ViewRiksdagenPartyRoleMember getPartyLeaderRole(ApplicationManager applicationManager, String personId) {
+        final DataContainer<ViewRiksdagenPartyRoleMember, String> container = 
+            applicationManager.getDataContainer(ViewRiksdagenPartyRoleMember.class);
+        final List<ViewRiksdagenPartyRoleMember> roles =
+            container.findListByProperty(new Object[] { personId, Boolean.TRUE },
+                    ViewRiksdagenPartyRoleMember_.personId,
+                    ViewRiksdagenPartyRoleMember_.active);
+
+        return roles.stream()
+                .filter(r -> r.getRoleCode() != null 
+                    && "Partiledare".equalsIgnoreCase(r.getRoleCode().trim()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public static Map<String, Boolean> computePartyLeaders(ApplicationManager applicationManager, Iterable<String> personIds) {
+        final DataContainer<ViewRiksdagenPartyRoleMember, String> container = 
+            applicationManager.getDataContainer(ViewRiksdagenPartyRoleMember.class);
+
+        final Map<String, Boolean> result = new HashMap<>();
+        for (String personId : personIds) {
+            final List<ViewRiksdagenPartyRoleMember> roles =
+                container.findListByProperty(new Object[] { personId, Boolean.TRUE },
+                        ViewRiksdagenPartyRoleMember_.personId,
+                        ViewRiksdagenPartyRoleMember_.active);
+
+            final boolean isLeader = roles.stream()
+                    .anyMatch(r -> r.getRoleCode() != null 
+                        && "Partiledare".equalsIgnoreCase(r.getRoleCode().trim()));
+            result.put(personId, isLeader);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Centralize common 'party leader' logic into a utility class and update relevant classes to use it.

* Add `PartyLeaderUtil` class in `com.hack23.cia.web.impl.ui.application.util` package
  - Add `isPartyLeader` method
  - Add `getPartyLeaderRole` method
  - Add `computePartyLeaders` method

* Update `PartyRankingCurrentPartiesLeaderScoreboardPageModContentFactoryImpl`
  - Replace `isPartyLeader` method with `PartyLeaderUtil.isPartyLeader`
  - Replace `getPartyLeaderRole` method with `PartyLeaderUtil.getPartyLeaderRole`
  - Replace `computePartyLeaders` method with `PartyLeaderUtil.computePartyLeaders`

* Update `MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModContentFactoryImpl`
  - Replace `isPartyLeader` method with `PartyLeaderUtil.isPartyLeader`
  - Replace `getPartyLeaderRole` method with `PartyLeaderUtil.getPartyLeaderRole`
  - Replace `computePartyLeaders` method with `PartyLeaderUtil.computePartyLeaders`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/cia/pull/6944?shareId=b3b38479-4a33-427b-a0cb-d558031fa696).