### PR TITLE
feat: Add GitHub Codespaces development environment configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,35 @@
+FROM mcr.microsoft.com/devcontainers/java:21-bullseye
+
+# Install additional packages
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    graphviz \
+    build-essential \
+    fakeroot \
+    devscripts \
+    debhelper \
+    dh-make \
+    wget \
+    tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set timezone to match your workflow (Europe/Stockholm)
+RUN ln -fs /usr/share/zoneinfo/Europe/Stockholm /etc/localtime \
+    && dpkg-reconfigure -f noninteractive tzdata
+
+# Install specific Maven version (3.9.9 to match your workflow)
+ARG MAVEN_VERSION=3.9.9
+RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+    | tar xzvf - -C /usr/local/ \
+    && ln -s /usr/local/apache-maven-${MAVEN_VERSION} /usr/local/maven \
+    && ln -s /usr/local/maven/bin/mvn /usr/local/bin/mvn
+
+# Set Maven environment variables
+ENV MAVEN_HOME=/usr/local/maven
+ENV PATH=${PATH}:${MAVEN_HOME}/bin
+
+# Set working directory
+WORKDIR /workspace
+
+# Cache Maven packages
+VOLUME /root/.m2

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "CIA Java Development Environment",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "settings": {
+    "terminal.integrated.defaultProfile.linux": "bash",
+    "java.jdt.ls.java.home": "/usr/local/sdkman/candidates/java/current",
+    "maven.executable.path": "/usr/local/sdkman/candidates/maven/current/bin/mvn"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "21",
+      "distribution": "temurin"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "GitHub.copilot",
+        "redhat.vscode-xml",
+        "vscjava.vscode-maven"
+      ]
+    }
+  },
+  "forwardPorts": [],
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y graphviz build-essential fakeroot devscripts debhelper dh-make",
+  "remoteUser": "vscode"
+}


### PR DESCRIPTION
- Add .devcontainer/devcontainer.json for Codespaces configuration
- Add .devcontainer/Dockerfile with Java 21 and Maven 3.9.9 setup
- Configure development environment matching CI/CD pipeline
- Include required build tools (graphviz, build-essential, etc.)
- Set timezone to Europe/Stockholm
- Enable Maven package caching
- Add essential Java development VS Code extensions

By submitting a request, you represent that you have the right to license
your contribution to the community, and agree that your contributions are
licensed under the [The Apache Software License, Version 2.0](LICENSE.txt).
