### PR TITLE
Refactor leader card utility

### DIFF
--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/util/LeaderCardUtil.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/util/LeaderCardUtil.java
@@ -1,0 +1,382 @@
+package com.hack23.cia.web.impl.ui.application.util;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.hack23.cia.model.internal.application.data.ministry.impl.ViewRiksdagenGovermentRoleMember;
+import com.hack23.cia.model.internal.application.data.ministry.impl.ViewRiksdagenGovermentRoleMember_;
+import com.hack23.cia.model.internal.application.data.party.impl.ViewRiksdagenPartyRoleMember;
+import com.hack23.cia.model.internal.application.data.politician.impl.ViewRiksdagenPolitician;
+import com.hack23.cia.model.internal.application.data.politician.impl.ViewRiksdagenPoliticianBallotSummary;
+import com.hack23.cia.model.internal.application.data.politician.impl.ViewRiksdagenPoliticianExperienceSummary;
+import com.hack23.cia.service.api.ApplicationManager;
+import com.hack23.cia.service.api.DataContainer;
+import com.hack23.cia.service.external.esv.api.EsvApi;
+import com.hack23.cia.service.external.esv.api.GovernmentBodyAnnualOutcomeSummary;
+import com.hack23.cia.service.external.esv.api.GovernmentBodyAnnualSummary;
+import com.hack23.cia.web.impl.ui.application.views.common.pagemode.CardInfoRowUtil;
+import com.hack23.cia.web.impl.ui.application.views.common.pagemode.PoliticianLeaderboardUtil;
+import com.vaadin.server.ExternalResource;
+import com.vaadin.server.Responsive;
+import com.vaadin.shared.ui.ContentMode;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.Link;
+import com.vaadin.ui.Panel;
+import com.vaadin.ui.VerticalLayout;
+
+@Component
+public class LeaderCardUtil {
+
+    @Autowired
+    private ApplicationManager applicationManager;
+
+    @Autowired
+    private PoliticianLeaderboardUtil politicianLeaderboardUtil;
+
+    @Autowired
+    private EsvApi esvApi;
+
+    public List<ViewRiksdagenGovermentRoleMember> loadActiveGovernmentRoleMembers() {
+        final DataContainer<ViewRiksdagenGovermentRoleMember, String> govermentRoleMemberDataContainer = applicationManager
+                .getDataContainer(ViewRiksdagenGovermentRoleMember.class);
+        return govermentRoleMemberDataContainer.findListByProperty(new Object[] { Boolean.TRUE },
+                ViewRiksdagenGovermentRoleMember_.active);
+    }
+
+    public Map<String, List<ViewRiksdagenPolitician>> loadActivePoliticiansByPersonId() {
+        final DataContainer<ViewRiksdagenPolitician, String> politicianDataContainer = applicationManager
+                .getDataContainer(ViewRiksdagenPolitician.class);
+        final List<ViewRiksdagenPolitician> activePoliticians = politicianDataContainer
+                .findListByProperty(new Object[] { Boolean.TRUE }, ViewRiksdagenPolitician_.activeGovernment);
+        return activePoliticians.stream().collect(Collectors.groupingBy(ViewRiksdagenPolitician::getPersonId));
+    }
+
+    public Panel createBaseballStyleCard(ViewRiksdagenGovermentRoleMember govMember,
+            ViewRiksdagenPolitician politician, ViewRiksdagenPoliticianBallotSummary ballotSummary, Map<String, List<GovernmentBodyAnnualSummary>> governmentBodyByMinistry,
+            Map<String, List<GovernmentBodyAnnualOutcomeSummary>> reportByMinistry, ViewRiksdagenPoliticianExperienceSummary experienceSummary) {
+
+        final Panel cardPanel = new Panel();
+        cardPanel.addStyleName("leader-baseball-card");
+        cardPanel.setSizeFull();
+        Responsive.makeResponsive(cardPanel);
+
+        final VerticalLayout cardContent = new VerticalLayout();
+        cardContent.setMargin(true);
+        cardContent.setSpacing(true);
+        cardContent.setSizeFull();
+        cardPanel.setContent(cardContent);
+
+        CardInfoRowUtil.createCardHeader(cardContent,govMember.getRoleCode() + " " + govMember.getFirstName() + " " + govMember.getLastName()
+            + " (" + govMember.getParty() + ")");
+        cardContent.addComponent(getPageLinkFactory().createPoliticianPageLink(politician));
+
+        final Link pageLink = new Link("Party " + politician.getParty(),
+                new ExternalResource("#!" + UserViews.PARTY_VIEW_NAME + "/" + politician.getParty()));
+        pageLink.setId(ViewAction.VISIT_PARTY_VIEW.name() + "/" + politician.getParty());
+        pageLink.setIcon(VaadinIcons.GROUP);
+
+        cardContent.addComponent(pageLink);
+
+        final boolean isPartyLeader = PartyLeaderUtil.isPartyLeader(applicationManager, politician.getPersonId());
+        if (isPartyLeader) {
+            final ViewRiksdagenPartyRoleMember leaderRole = PartyLeaderUtil.getPartyLeaderRole(applicationManager, politician.getPersonId());
+            if (leaderRole != null) {
+                final Label subHeader = new Label(
+                        "Partiledare (" + govMember.getParty() + ") since " + leaderRole.getFromDate());
+                subHeader.addStyleName("card-subtitle");
+                cardContent.addComponent(subHeader);
+            }
+        }
+
+        // After creating the divider following the header/subtitle
+        // We create a vertical layout to hold Tenure and Experience on separate rows
+        final VerticalLayout statsContainer = new VerticalLayout();
+        statsContainer.setSpacing(false); // Less space between rows
+        statsContainer.addStyleName("card-stats-container");
+        statsContainer.setWidth("100%");
+
+        // Tenure Row
+        final HorizontalLayout tenureLayout = new HorizontalLayout();
+        tenureLayout.setSpacing(true);
+        tenureLayout.addStyleName("card-tenure");
+        final Label tenureIcon = new Label(VaadinIcons.CLOCK.getHtml(), ContentMode.HTML);
+        tenureIcon.setDescription("Tenure in days");
+
+        final Label tenureLabel = new Label("Tenure:");
+        tenureLabel.addStyleName("card-tenure-text");
+
+        final Label tenureValue = new Label(govMember.getTotalDaysServed() + " days");
+        tenureValue.addStyleName("card-tenure-value");
+
+        tenureLayout.addComponents(tenureIcon, tenureLabel, tenureValue);
+        statsContainer.addComponent(tenureLayout);
+
+        // Experience Row
+        final HorizontalLayout experienceLayout = new HorizontalLayout();
+        experienceLayout.setSpacing(true);
+        experienceLayout.addStyleName("card-experience-section");
+        final Label expIcon = new Label(VaadinIcons.USER_CHECK.getHtml(), ContentMode.HTML);
+        expIcon.setDescription("Political Experience");
+
+        final Label expLabel = new Label("Experience:");
+        expLabel.addStyleName("card-experience-text");
+
+        final int govYears = (int) (politician.getTotalDaysServedGovernment() / 365);
+        final int partyYears = (int) (politician.getTotalDaysServedParty() / 365);
+        final int parliamentYears = (int) (politician.getTotalDaysServedParliament() / 365);
+        final Label expValue = new Label(
+                "Goverment: " + govYears + "y, Party: " + partyYears + "y, Parliament: " + parliamentYears + "y");
+        expValue.addStyleName("card-experience-value");
+
+        experienceLayout.addComponents(expIcon, expLabel, expValue);
+        statsContainer.addComponent(experienceLayout);
+
+        // Add the statsContainer to the cardContent
+        cardContent.addComponent(statsContainer);
+
+        // Create grid for the four sections
+        final HorizontalLayout sectionsGrid = new HorizontalLayout();
+        sectionsGrid.setSpacing(true);
+        sectionsGrid.setWidth("100%");
+
+        // Add the four main sections
+        final VerticalLayout politicalRoleLayout = CardInfoRowUtil.createSectionLayout("Political Role & Influence");
+        addPoliticalRoleMetrics(politicalRoleLayout, govMember, politician, ballotSummary, experienceSummary);
+        sectionsGrid.addComponent(politicalRoleLayout);
+
+        final VerticalLayout performanceLayout = CardInfoRowUtil.createSectionLayout("Parliamentary Performance");
+        politicianLeaderboardUtil.addParliamentaryPerformanceMetrics(performanceLayout, politician, ballotSummary);
+        sectionsGrid.addComponent(performanceLayout);
+
+        cardContent.addComponent(sectionsGrid);
+
+        final HorizontalLayout sections2Grid = new HorizontalLayout();
+        sections2Grid.setSpacing(true);
+        sections2Grid.setWidth("100%");
+
+        final VerticalLayout legislativeLayout = CardInfoRowUtil.createSectionLayout("Legislative Activity");
+        politicianLeaderboardUtil.addLegislativeMetrics(legislativeLayout, politician);
+        sections2Grid.addComponent(legislativeLayout);
+
+        final VerticalLayout alignmentLayout = CardInfoRowUtil.createSectionLayout("Party Alignment");
+        politicianLeaderboardUtil.addPartyAlignmentMetrics(alignmentLayout, politician, ballotSummary);
+        sections2Grid.addComponent(alignmentLayout);
+        cardContent.addComponent(sections2Grid);
+
+        politicianLeaderboardUtil.addMinistryRoleSummary(cardContent, govMember, governmentBodyByMinistry, reportByMinistry);
+
+        return cardPanel;
+    }
+
+    public Panel createLeaderCard(final ViewRiksdagenPolitician leader, final ViewRiksdagenPoliticianBallotSummary ballotSummary,
+            final Map<String, List<GovernmentBodyAnnualSummary>> governmentBodyByMinistry,
+            final Map<String, List<GovernmentBodyAnnualOutcomeSummary>> reportByMinistry, final ViewRiksdagenPoliticianExperienceSummary experienceSummary) {
+
+        final Panel cardPanel = new Panel();
+        cardPanel.addStyleName("leader-baseball-card");
+        cardPanel.setSizeFull();
+        Responsive.makeResponsive(cardPanel);
+
+        final VerticalLayout cardContent = new VerticalLayout();
+        cardContent.setMargin(true);
+        cardContent.setSpacing(true);
+        cardContent.setSizeFull();
+        cardPanel.setContent(cardContent);
+
+        CardInfoRowUtil.createCardHeader(cardContent,"Partiledare " + leader.getFirstName() + " " + leader.getLastName() + " ("
+                + leader.getParty() + ")");
+
+        // Politician detail link
+        cardContent.addComponent(getPageLinkFactory().createPoliticianPageLink(leader));
+
+        // Party link
+        final Link partyLink = new Link("Party " + leader.getParty(),
+                new ExternalResource("#!" + UserViews.PARTY_VIEW_NAME + "/" + leader.getParty()));
+        partyLink.setIcon(VaadinIcons.GROUP);
+        cardContent.addComponent(partyLink);
+
+        final boolean isPartyLeader = PartyLeaderUtil.isPartyLeader(applicationManager, leader.getPersonId());
+        if (isPartyLeader) {
+            final ViewRiksdagenPartyRoleMember leaderRole = PartyLeaderUtil.getPartyLeaderRole(applicationManager, leader.getPersonId());
+            if (leaderRole != null) {
+                final Label subHeader = new Label("Partiledare (" + leader.getParty() + ") since " + leaderRole.getFromDate());
+                subHeader.addStyleName("card-subtitle");
+                cardContent.addComponent(subHeader);
+            }
+        }
+
+        // Government or not
+        ViewRiksdagenGovermentRoleMember govMember = null;
+        if (leader.isActiveGovernment()) {
+            final Label govLabel = new Label("Currently in Government");
+            govLabel.addStyleName("card-subtitle");
+            cardContent.addComponent(govLabel);
+
+            // Add ministry summary if we can identify their ministry
+            // The ministry detail is stored in the same structure as the ministry snippet:
+            // We need to find which ministry they belong to
+            // In the ministry snippet, "govMember.getDetail()" gives ministry detail key.
+            // Here we only have leader, not govMember. We must find a corresponding approach:
+
+            // Let's assume we can identify the leader's ministry from active government roles data:
+            // we do similar approach: load active government role members and find the one matching this leader
+            final ViewRiksdagenPolitician pol = leader; // same as leader
+            govMember = findGovernmentRoleForLeader(pol);
+            if (govMember != null) {
+                politicianLeaderboardUtil.addMinistryRoleSummary(cardContent, govMember, governmentBodyByMinistry, reportByMinistry);
+            }
+
+        } else {
+            final Label nonGovLabel = new Label("Not in Government");
+            nonGovLabel.addStyleName("card-subtitle-nongov");
+            cardContent.addComponent(nonGovLabel);
+        }
+
+        // Tenure and Experience rows
+        final VerticalLayout statsContainer = new VerticalLayout();
+        statsContainer.setSpacing(false);
+        statsContainer.addStyleName("card-stats-container");
+        statsContainer.setWidth("100%");
+
+        // Tenure (assuming leader might have totalDaysServed property)
+        final Label tenureIcon = new Label(VaadinIcons.CLOCK.getHtml(), ContentMode.HTML);
+        tenureIcon.setDescription("Total Tenure");
+        final Label tenureLabel = new Label("Tenure:");
+        tenureLabel.addStyleName("card-tenure-text");
+        final Label tenureValue = new Label(leader.getTotalDaysServedParty() + " days");
+        tenureValue.addStyleName("card-tenure-value");
+        final HorizontalLayout tenureLayout = new HorizontalLayout(tenureIcon, tenureLabel, tenureValue);
+        tenureLayout.setSpacing(true);
+        tenureLayout.addStyleName("card-tenure");
+        statsContainer.addComponent(tenureLayout);
+
+        // Experience
+        final HorizontalLayout experienceLayout = new HorizontalLayout();
+        experienceLayout.setSpacing(true);
+        experienceLayout.addStyleName("card-experience-section");
+        final Label expIcon = new Label(VaadinIcons.USER_CHECK.getHtml(), ContentMode.HTML);
+        expIcon.setDescription("Political Experience");
+        final Label expLabel = new Label("Experience:");
+        expLabel.addStyleName("card-experience-text");
+
+        final int govYears = (int) (leader.getTotalDaysServedGovernment() / 365);
+        final int partyYears = (int) (leader.getTotalDaysServedParty() / 365);
+        final int parliamentYears = (int) (leader.getTotalDaysServedParliament() / 365);
+        final String expText = String.format(Locale.ENGLISH, "Government: %dy, Party: %dy, Parliament: %dy",
+                govYears, partyYears, parliamentYears);
+        final Label expValue = new Label(expText);
+        expValue.addStyleName("card-experience-value");
+        experienceLayout.addComponents(expIcon, expLabel, expValue);
+        statsContainer.addComponent(experienceLayout);
+
+        cardContent.addComponent(statsContainer);
+
+        // Create grid for the four sections
+        final HorizontalLayout sectionsGrid = new HorizontalLayout();
+        sectionsGrid.setSpacing(true);
+        sectionsGrid.setWidth("100%");
+
+        // Add the four main sections
+        final VerticalLayout politicalRoleLayout = CardInfoRowUtil.createSectionLayout("Political Role & Influence");
+        addPoliticalRoleMetrics(politicalRoleLayout, PartyLeaderUtil.getPartyLeaderRole(applicationManager, leader.getPersonId()), govMember, leader, ballotSummary,experienceSummary);
+        sectionsGrid.addComponent(politicalRoleLayout);
+
+        final VerticalLayout performanceLayout = CardInfoRowUtil.createSectionLayout("Parliamentary Performance");
+        politicianLeaderboardUtil.addParliamentaryPerformanceMetrics(performanceLayout, leader, ballotSummary);
+        sectionsGrid.addComponent(performanceLayout);
+
+        cardContent.addComponent(sectionsGrid);
+
+        final HorizontalLayout sections2Grid = new HorizontalLayout();
+        sections2Grid.setSpacing(true);
+        sections2Grid.setWidth("100%");
+
+        final VerticalLayout legislativeLayout = CardInfoRowUtil.createSectionLayout("Legislative Activity");
+        politicianLeaderboardUtil.addLegislativeMetrics(legislativeLayout, leader);
+        sections2Grid.addComponent(legislativeLayout);
+
+        final VerticalLayout alignmentLayout = CardInfoRowUtil.createSectionLayout("Party Alignment");
+        politicianLeaderboardUtil.addPartyAlignmentMetrics(alignmentLayout, leader, ballotSummary);
+        sections2Grid.addComponent(alignmentLayout);
+        cardContent.addComponent(sections2Grid);
+
+        return cardPanel;
+    }
+
+    private void addPoliticalRoleMetrics(VerticalLayout layout, ViewRiksdagenGovermentRoleMember govMember,
+            ViewRiksdagenPolitician politician, ViewRiksdagenPoliticianBallotSummary ballotSummary, ViewRiksdagenPoliticianExperienceSummary experienceSummary) {
+
+        layout.addComponent(CardInfoRowUtil.createInfoRow("Current Role:", govMember.getRoleCode(), VaadinIcons.INSTITUTION,
+                "Current position in parliament"));
+        layout.addComponent(CardInfoRowUtil.createInfoRow("Career Length:",
+                String.format(Locale.ENGLISH,"%,d days", govMember.getTotalDaysServed()),
+                VaadinIcons.TIMER, "Years in parliament"));
+        layout.addComponent(CardInfoRowUtil.createInfoRow("Total Propositions:",
+                String.format(Locale.ENGLISH,"%,d", govMember.getTotalPropositions()),
+                VaadinIcons.GROUP, "Total Propositions"));
+        layout.addComponent(CardInfoRowUtil.createInfoRow("Total Government Bills:",
+                String.format(Locale.ENGLISH,"%,d", govMember.getTotalGovernmentBills()),
+                VaadinIcons.GROUP, "Total Government Bills"));
+
+        politicianLeaderboardUtil.addTopRoles(layout, experienceSummary);
+        politicianLeaderboardUtil.addKnowledgeAreas(layout, experienceSummary);
+        politicianLeaderboardUtil.addExperienceMetrics(layout,experienceSummary);
+        politicianLeaderboardUtil.addPoliticalAnalysisComment(layout, experienceSummary);
+
+    }
+
+    private void addPoliticalRoleMetrics(VerticalLayout layout, ViewRiksdagenPartyRoleMember riksdagenPartyRoleMember, ViewRiksdagenGovermentRoleMember govMember,
+            ViewRiksdagenPolitician politician, ViewRiksdagenPoliticianBallotSummary ballotSummary, ViewRiksdagenPoliticianExperienceSummary experienceSummary) {
+
+        addPartyExperince(layout, riksdagenPartyRoleMember, govMember, politician);
+
+        // Top Roles
+        politicianLeaderboardUtil.addTopRoles(layout, experienceSummary);
+
+        // Top Knowledge Areas
+        politicianLeaderboardUtil.addKnowledgeAreas(layout, experienceSummary);
+
+        politicianLeaderboardUtil.addExperienceMetrics(layout,experienceSummary);
+
+        politicianLeaderboardUtil.addPoliticalAnalysisComment(layout, experienceSummary);
+
+    }
+
+    private void addPartyExperince(VerticalLayout layout, ViewRiksdagenPartyRoleMember riksdagenPartyRoleMember,
+            ViewRiksdagenGovermentRoleMember govMember, ViewRiksdagenPolitician politician) {
+        if (govMember != null) {
+            layout.addComponent(CardInfoRowUtil.createInfoRow("Role:", govMember != null ? govMember.getRoleCode() : "N/A", VaadinIcons.INSTITUTION,
+                    "Current position in Government"));
+            layout.addComponent(CardInfoRowUtil.createInfoRow("Career Length Government:",
+                    String.format(Locale.ENGLISH,"%,d days", govMember != null ? govMember.getTotalDaysServed() : 0),
+                    VaadinIcons.TIMER, "Years in Government"));
+        } else {
+            layout.addComponent(CardInfoRowUtil.createInfoRow("Career Length Parlimanet:",
+                    String.format(Locale.ENGLISH,"%,d days", politician != null ? politician.getTotalDaysServedParliament() : 0),
+                    VaadinIcons.TIMER, "Years in Parlimanet"));
+        }
+
+        layout.addComponent(CardInfoRowUtil.createInfoRow("Current Party Role:", riksdagenPartyRoleMember != null ? riksdagenPartyRoleMember.getRoleCode() : "N/A", VaadinIcons.INSTITUTION,
+                "Current position in Party"));
+        layout.addComponent(CardInfoRowUtil.createInfoRow("Career Length Party Leader:",
+                String.format(Locale.ENGLISH,"%,d days", riksdagenPartyRoleMember != null ? riksdagenPartyRoleMember.getTotalDaysServed() : 0),
+                VaadinIcons.TIMER, "Years as Party Leader"));
+    }
+
+    private ViewRiksdagenGovermentRoleMember findGovernmentRoleForLeader(ViewRiksdagenPolitician leader) {
+        final DataContainer<ViewRiksdagenGovermentRoleMember, String> govermentRoleMemberDataContainer = applicationManager
+                .getDataContainer(ViewRiksdagenGovermentRoleMember.class);
+        final List<ViewRiksdagenGovermentRoleMember> activeGovMembers = govermentRoleMemberDataContainer.findListByProperty(
+                new Object[] { Boolean.TRUE }, ViewRiksdagenGovermentRoleMember_.active);
+
+        return activeGovMembers.stream()
+                .filter(govMember -> govMember.getPersonId().equals(leader.getPersonId()))
+                .findFirst().orElse(null);
+    }
+}

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/util/LeaderCardUtil.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/util/LeaderCardUtil.java
@@ -14,13 +14,17 @@ import com.hack23.cia.model.internal.application.data.party.impl.ViewRiksdagenPa
 import com.hack23.cia.model.internal.application.data.politician.impl.ViewRiksdagenPolitician;
 import com.hack23.cia.model.internal.application.data.politician.impl.ViewRiksdagenPoliticianBallotSummary;
 import com.hack23.cia.model.internal.application.data.politician.impl.ViewRiksdagenPoliticianExperienceSummary;
+import com.hack23.cia.model.internal.application.data.politician.impl.ViewRiksdagenPolitician_;
 import com.hack23.cia.service.api.ApplicationManager;
 import com.hack23.cia.service.api.DataContainer;
-import com.hack23.cia.service.external.esv.api.EsvApi;
 import com.hack23.cia.service.external.esv.api.GovernmentBodyAnnualOutcomeSummary;
 import com.hack23.cia.service.external.esv.api.GovernmentBodyAnnualSummary;
+import com.hack23.cia.web.impl.ui.application.action.ViewAction;
+import com.hack23.cia.web.impl.ui.application.views.common.pagelinks.api.PageLinkFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.pagemode.CardInfoRowUtil;
 import com.hack23.cia.web.impl.ui.application.views.common.pagemode.PoliticianLeaderboardUtil;
+import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
+import com.vaadin.icons.VaadinIcons;
 import com.vaadin.server.ExternalResource;
 import com.vaadin.server.Responsive;
 import com.vaadin.shared.ui.ContentMode;
@@ -30,18 +34,29 @@ import com.vaadin.ui.Link;
 import com.vaadin.ui.Panel;
 import com.vaadin.ui.VerticalLayout;
 
+/**
+ * The Class LeaderCardUtil.
+ */
 @Component
 public class LeaderCardUtil {
 
+    /** The application manager. */
     @Autowired
     private ApplicationManager applicationManager;
 
+    /** The politician leaderboard util. */
     @Autowired
     private PoliticianLeaderboardUtil politicianLeaderboardUtil;
 
-    @Autowired
-    private EsvApi esvApi;
+	/** The page link factory. */
+	@Autowired
+	public PageLinkFactory pageLinkFactory;
 
+    /**
+     * Load active government role members.
+     *
+     * @return the list
+     */
     public List<ViewRiksdagenGovermentRoleMember> loadActiveGovernmentRoleMembers() {
         final DataContainer<ViewRiksdagenGovermentRoleMember, String> govermentRoleMemberDataContainer = applicationManager
                 .getDataContainer(ViewRiksdagenGovermentRoleMember.class);
@@ -49,14 +64,31 @@ public class LeaderCardUtil {
                 ViewRiksdagenGovermentRoleMember_.active);
     }
 
+    /**
+     * Load active politicians by person id.
+     *
+     * @return the map
+     */
     public Map<String, List<ViewRiksdagenPolitician>> loadActivePoliticiansByPersonId() {
         final DataContainer<ViewRiksdagenPolitician, String> politicianDataContainer = applicationManager
                 .getDataContainer(ViewRiksdagenPolitician.class);
         final List<ViewRiksdagenPolitician> activePoliticians = politicianDataContainer
-                .findListByProperty(new Object[] { Boolean.TRUE }, ViewRiksdagenPolitician_.activeGovernment);
+                .findListByProperty(new Object[] { Boolean.TRUE }, ViewRiksdagenPolitician_.active);
         return activePoliticians.stream().collect(Collectors.groupingBy(ViewRiksdagenPolitician::getPersonId));
     }
 
+
+    /**
+     * Creates the baseball style card.
+     *
+     * @param govMember the gov member
+     * @param politician the politician
+     * @param ballotSummary the ballot summary
+     * @param governmentBodyByMinistry the government body by ministry
+     * @param reportByMinistry the report by ministry
+     * @param experienceSummary the experience summary
+     * @return the panel
+     */
     public Panel createBaseballStyleCard(ViewRiksdagenGovermentRoleMember govMember,
             ViewRiksdagenPolitician politician, ViewRiksdagenPoliticianBallotSummary ballotSummary, Map<String, List<GovernmentBodyAnnualSummary>> governmentBodyByMinistry,
             Map<String, List<GovernmentBodyAnnualOutcomeSummary>> reportByMinistry, ViewRiksdagenPoliticianExperienceSummary experienceSummary) {
@@ -74,7 +106,7 @@ public class LeaderCardUtil {
 
         CardInfoRowUtil.createCardHeader(cardContent,govMember.getRoleCode() + " " + govMember.getFirstName() + " " + govMember.getLastName()
             + " (" + govMember.getParty() + ")");
-        cardContent.addComponent(getPageLinkFactory().createPoliticianPageLink(politician));
+        cardContent.addComponent(pageLinkFactory.createPoliticianPageLink(politician));
 
         final Link pageLink = new Link("Party " + politician.getParty(),
                 new ExternalResource("#!" + UserViews.PARTY_VIEW_NAME + "/" + politician.getParty()));
@@ -174,6 +206,16 @@ public class LeaderCardUtil {
         return cardPanel;
     }
 
+    /**
+     * Creates the leader card.
+     *
+     * @param leader the leader
+     * @param ballotSummary the ballot summary
+     * @param governmentBodyByMinistry the government body by ministry
+     * @param reportByMinistry the report by ministry
+     * @param experienceSummary the experience summary
+     * @return the panel
+     */
     public Panel createLeaderCard(final ViewRiksdagenPolitician leader, final ViewRiksdagenPoliticianBallotSummary ballotSummary,
             final Map<String, List<GovernmentBodyAnnualSummary>> governmentBodyByMinistry,
             final Map<String, List<GovernmentBodyAnnualOutcomeSummary>> reportByMinistry, final ViewRiksdagenPoliticianExperienceSummary experienceSummary) {
@@ -193,7 +235,7 @@ public class LeaderCardUtil {
                 + leader.getParty() + ")");
 
         // Politician detail link
-        cardContent.addComponent(getPageLinkFactory().createPoliticianPageLink(leader));
+        cardContent.addComponent(pageLinkFactory.createPoliticianPageLink(leader));
 
         // Party link
         final Link partyLink = new Link("Party " + leader.getParty(),
@@ -309,6 +351,15 @@ public class LeaderCardUtil {
         return cardPanel;
     }
 
+    /**
+     * Adds the political role metrics.
+     *
+     * @param layout the layout
+     * @param govMember the gov member
+     * @param politician the politician
+     * @param ballotSummary the ballot summary
+     * @param experienceSummary the experience summary
+     */
     private void addPoliticalRoleMetrics(VerticalLayout layout, ViewRiksdagenGovermentRoleMember govMember,
             ViewRiksdagenPolitician politician, ViewRiksdagenPoliticianBallotSummary ballotSummary, ViewRiksdagenPoliticianExperienceSummary experienceSummary) {
 
@@ -331,6 +382,16 @@ public class LeaderCardUtil {
 
     }
 
+    /**
+     * Adds the political role metrics.
+     *
+     * @param layout the layout
+     * @param riksdagenPartyRoleMember the riksdagen party role member
+     * @param govMember the gov member
+     * @param politician the politician
+     * @param ballotSummary the ballot summary
+     * @param experienceSummary the experience summary
+     */
     private void addPoliticalRoleMetrics(VerticalLayout layout, ViewRiksdagenPartyRoleMember riksdagenPartyRoleMember, ViewRiksdagenGovermentRoleMember govMember,
             ViewRiksdagenPolitician politician, ViewRiksdagenPoliticianBallotSummary ballotSummary, ViewRiksdagenPoliticianExperienceSummary experienceSummary) {
 
@@ -348,6 +409,14 @@ public class LeaderCardUtil {
 
     }
 
+    /**
+     * Adds the party experince.
+     *
+     * @param layout the layout
+     * @param riksdagenPartyRoleMember the riksdagen party role member
+     * @param govMember the gov member
+     * @param politician the politician
+     */
     private void addPartyExperince(VerticalLayout layout, ViewRiksdagenPartyRoleMember riksdagenPartyRoleMember,
             ViewRiksdagenGovermentRoleMember govMember, ViewRiksdagenPolitician politician) {
         if (govMember != null) {
@@ -369,6 +438,12 @@ public class LeaderCardUtil {
                 VaadinIcons.TIMER, "Years as Party Leader"));
     }
 
+    /**
+     * Find government role for leader.
+     *
+     * @param leader the leader
+     * @return the view riksdagen goverment role member
+     */
     private ViewRiksdagenGovermentRoleMember findGovernmentRoleForLeader(ViewRiksdagenPolitician leader) {
         final DataContainer<ViewRiksdagenGovermentRoleMember, String> govermentRoleMemberDataContainer = applicationManager
                 .getDataContainer(ViewRiksdagenGovermentRoleMember.class);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModContentFactoryImpl.java
@@ -11,34 +11,22 @@ import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Service;
 
 import com.hack23.cia.model.internal.application.data.ministry.impl.ViewRiksdagenGovermentRoleMember;
-import com.hack23.cia.model.internal.application.data.ministry.impl.ViewRiksdagenGovermentRoleMember_;
-import com.hack23.cia.model.internal.application.data.party.impl.ViewRiksdagenPartyRoleMember;
 import com.hack23.cia.model.internal.application.data.politician.impl.ViewRiksdagenPolitician;
 import com.hack23.cia.model.internal.application.data.politician.impl.ViewRiksdagenPoliticianBallotSummary;
 import com.hack23.cia.model.internal.application.data.politician.impl.ViewRiksdagenPoliticianExperienceSummary;
-import com.hack23.cia.model.internal.application.data.politician.impl.ViewRiksdagenPolitician_;
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
-import com.hack23.cia.service.api.DataContainer;
 import com.hack23.cia.service.external.esv.api.EsvApi;
 import com.hack23.cia.service.external.esv.api.GovernmentBodyAnnualOutcomeSummary;
 import com.hack23.cia.service.external.esv.api.GovernmentBodyAnnualSummary;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
 import com.hack23.cia.web.impl.ui.application.util.LeaderCardUtil;
+import com.hack23.cia.web.impl.ui.application.util.PartyLeaderUtil;
 import com.hack23.cia.web.impl.ui.application.views.common.pagemode.CardInfoRowUtil;
-import com.hack23.cia.web.impl.ui.application.views.common.pagemode.PoliticianLeaderboardUtil;
 import com.hack23.cia.web.impl.ui.application.views.common.rows.RowUtil;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.ChartIndicators;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PageMode;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 import com.jarektoro.responsivelayout.ResponsiveRow;
-import com.vaadin.icons.VaadinIcons;
-import com.vaadin.server.ExternalResource;
-import com.vaadin.server.Responsive;
-import com.vaadin.shared.ui.ContentMode;
-import com.vaadin.ui.HorizontalLayout;
-import com.vaadin.ui.Label;
 import com.vaadin.ui.Layout;
-import com.vaadin.ui.Link;
 import com.vaadin.ui.MenuBar;
 import com.vaadin.ui.Panel;
 import com.vaadin.ui.VerticalLayout;
@@ -68,9 +56,7 @@ public final class MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModCon
 	/** The esv api. */
 	private final EsvApi esvApi;
 
-	@Autowired
-	private PoliticianLeaderboardUtil politicianLeaderboardUtil;
-
+	/** The leader card util. */
 	@Autowired
 	private LeaderCardUtil leaderCardUtil;
 
@@ -114,7 +100,7 @@ public final class MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModCon
 		final List<ViewRiksdagenGovermentRoleMember> activeGovMembers = leaderCardUtil.loadActiveGovernmentRoleMembers();
 		final Map<String, List<ViewRiksdagenPolitician>> activePoliticianMap = leaderCardUtil.loadActivePoliticiansByPersonId();
 
-		final Map<String, Boolean> partyLeaderMap = leaderCardUtil.computePartyLeaders(activePoliticianMap.keySet());
+		final Map<String, Boolean> partyLeaderMap = PartyLeaderUtil.computePartyLeaders( getApplicationManager() ,activePoliticianMap.keySet());
 
 		// Sort roles
 		activeGovMembers.sort((a, b) -> {

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/goverment/pagemode/MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModContentFactoryImpl.java
@@ -23,7 +23,7 @@ import com.hack23.cia.service.external.esv.api.EsvApi;
 import com.hack23.cia.service.external.esv.api.GovernmentBodyAnnualOutcomeSummary;
 import com.hack23.cia.service.external.esv.api.GovernmentBodyAnnualSummary;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
-import com.hack23.cia.web.impl.ui.application.util.PartyLeaderUtil;
+import com.hack23.cia.web.impl.ui.application.util.LeaderCardUtil;
 import com.hack23.cia.web.impl.ui.application.views.common.pagemode.CardInfoRowUtil;
 import com.hack23.cia.web.impl.ui.application.views.common.pagemode.PoliticianLeaderboardUtil;
 import com.hack23.cia.web.impl.ui.application.views.common.rows.RowUtil;
@@ -71,6 +71,8 @@ public final class MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModCon
 	@Autowired
 	private PoliticianLeaderboardUtil politicianLeaderboardUtil;
 
+	@Autowired
+	private LeaderCardUtil leaderCardUtil;
 
 	/**
 	 * Instantiates a new ministry ranking current parties leader scoreboard charts page mod content factory impl.
@@ -109,10 +111,10 @@ public final class MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModCon
 		final ResponsiveRow row = RowUtil.createGridLayout(panelContent);
 		row.setSizeFull();
 
-		final List<ViewRiksdagenGovermentRoleMember> activeGovMembers = loadActiveGovernmentRoleMembers();
-		final Map<String, List<ViewRiksdagenPolitician>> activePoliticianMap = loadActivePoliticiansByPersonId();
+		final List<ViewRiksdagenGovermentRoleMember> activeGovMembers = leaderCardUtil.loadActiveGovernmentRoleMembers();
+		final Map<String, List<ViewRiksdagenPolitician>> activePoliticianMap = leaderCardUtil.loadActivePoliticiansByPersonId();
 
-		final Map<String, Boolean> partyLeaderMap = PartyLeaderUtil.computePartyLeaders(getApplicationManager(), activePoliticianMap.keySet());
+		final Map<String, Boolean> partyLeaderMap = leaderCardUtil.computePartyLeaders(activePoliticianMap.keySet());
 
 		// Sort roles
 		activeGovMembers.sort((a, b) -> {
@@ -138,7 +140,7 @@ public final class MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModCon
 		    final ViewRiksdagenPoliticianExperienceSummary experienceSummary = getApplicationManager().getDataContainer(ViewRiksdagenPoliticianExperienceSummary.class).load(govMember.getPersonId());
 
 
-			final Panel cardPanel = createBaseballStyleCard(govMember, politician, ballotSummary, governmentBodyByMinistry,
+			final Panel cardPanel = leaderCardUtil.createBaseballStyleCard(govMember, politician, ballotSummary, governmentBodyByMinistry,
 					reportByMinistry,experienceSummary);
 
 			// Responsive column rules
@@ -150,31 +152,6 @@ public final class MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModCon
 				NAME, parameters, pageId);
 
 		return panelContent;
-	}
-
-	/**
-	 * Load active government role members.
-	 *
-	 * @return the list
-	 */
-	private List<ViewRiksdagenGovermentRoleMember> loadActiveGovernmentRoleMembers() {
-		final DataContainer<ViewRiksdagenGovermentRoleMember, String> govermentRoleMemberDataContainer = getApplicationManager()
-				.getDataContainer(ViewRiksdagenGovermentRoleMember.class);
-		return govermentRoleMemberDataContainer.findListByProperty(new Object[] { Boolean.TRUE },
-				ViewRiksdagenGovermentRoleMember_.active);
-	}
-
-	/**
-	 * Load active politicians by person id.
-	 *
-	 * @return the map
-	 */
-	private Map<String, List<ViewRiksdagenPolitician>> loadActivePoliticiansByPersonId() {
-		final DataContainer<ViewRiksdagenPolitician, String> politicianDataContainer = getApplicationManager()
-				.getDataContainer(ViewRiksdagenPolitician.class);
-		final List<ViewRiksdagenPolitician> activePoliticians = politicianDataContainer
-				.findListByProperty(new Object[] { Boolean.TRUE }, ViewRiksdagenPolitician_.activeGovernment);
-		return activePoliticians.stream().collect(Collectors.groupingBy(ViewRiksdagenPolitician::getPersonId));
 	}
 
 	/**
@@ -197,167 +174,6 @@ public final class MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModCon
 		} else {
 			return 5;
 		}
-	}
-
-	/**
-	 * Creates the baseball style card.
-	 *
-	 * @param govMember the gov member
-	 * @param politician the politician
-	 * @param ballotSummary the ballot summary
-	 * @param governmentBodyByMinistry the government body by ministry
-	 * @param reportByMinistry the report by ministry
-	 * @param experienceSummary
-	 * @return the panel
-	 */
-	private Panel createBaseballStyleCard(ViewRiksdagenGovermentRoleMember govMember,
-			ViewRiksdagenPolitician politician, ViewRiksdagenPoliticianBallotSummary ballotSummary, Map<String, List<GovernmentBodyAnnualSummary>> governmentBodyByMinistry,
-			Map<String, List<GovernmentBodyAnnualOutcomeSummary>> reportByMinistry, ViewRiksdagenPoliticianExperienceSummary experienceSummary) {
-
-		final Panel cardPanel = new Panel();
-		cardPanel.addStyleName("leader-baseball-card");
-		cardPanel.setSizeFull();
-		Responsive.makeResponsive(cardPanel);
-
-		final VerticalLayout cardContent = new VerticalLayout();
-		cardContent.setMargin(true);
-		cardContent.setSpacing(true);
-		cardContent.setSizeFull();
-		cardPanel.setContent(cardContent);
-
-		 CardInfoRowUtil.createCardHeader(cardContent,govMember.getRoleCode() + " " + govMember.getFirstName() + " " + govMember.getLastName()
-			+ " (" + govMember.getParty() + ")");
-		cardContent.addComponent(getPageLinkFactory().createPoliticianPageLink(politician));
-
-		final Link pageLink = new Link("Party " + politician.getParty(),
-				new ExternalResource("#!" + UserViews.PARTY_VIEW_NAME + "/" + politician.getParty()));
-		pageLink.setId(ViewAction.VISIT_PARTY_VIEW.name() + "/" + politician.getParty());
-		pageLink.setIcon(VaadinIcons.GROUP);
-
-		cardContent.addComponent(pageLink);
-
-		final boolean isPartyLeader = PartyLeaderUtil.isPartyLeader(getApplicationManager(), politician.getPersonId());
-		if (isPartyLeader) {
-			final ViewRiksdagenPartyRoleMember leaderRole = PartyLeaderUtil.getPartyLeaderRole(getApplicationManager(), politician.getPersonId());
-			if (leaderRole != null) {
-				final Label subHeader = new Label(
-						"Partiledare (" + govMember.getParty() + ") since " + leaderRole.getFromDate());
-				subHeader.addStyleName("card-subtitle");
-				cardContent.addComponent(subHeader);
-			}
-		}
-
-		// After creating the divider following the header/subtitle
-		// We create a vertical layout to hold Tenure and Experience on separate rows
-		final VerticalLayout statsContainer = new VerticalLayout();
-		statsContainer.setSpacing(false); // Less space between rows
-		statsContainer.addStyleName("card-stats-container");
-		statsContainer.setWidth("100%");
-
-		// Tenure Row
-		final HorizontalLayout tenureLayout = new HorizontalLayout();
-		tenureLayout.setSpacing(true);
-		tenureLayout.addStyleName("card-tenure");
-		final Label tenureIcon = new Label(VaadinIcons.CLOCK.getHtml(), ContentMode.HTML);
-		tenureIcon.setDescription("Tenure in days");
-
-		final Label tenureLabel = new Label("Tenure:");
-		tenureLabel.addStyleName("card-tenure-text");
-
-		final Label tenureValue = new Label(govMember.getTotalDaysServed() + " days");
-		tenureValue.addStyleName("card-tenure-value");
-
-		tenureLayout.addComponents(tenureIcon, tenureLabel, tenureValue);
-		statsContainer.addComponent(tenureLayout);
-
-		// Experience Row
-		final HorizontalLayout experienceLayout = new HorizontalLayout();
-		experienceLayout.setSpacing(true);
-		experienceLayout.addStyleName("card-experience-section");
-		final Label expIcon = new Label(VaadinIcons.USER_CHECK.getHtml(), ContentMode.HTML);
-		expIcon.setDescription("Political Experience");
-
-		final Label expLabel = new Label("Experience:");
-		expLabel.addStyleName("card-experience-text");
-
-		final int govYears = (int) (politician.getTotalDaysServedGovernment() / 365);
-		final int partyYears = (int) (politician.getTotalDaysServedParty() / 365);
-		final int parliamentYears = (int) (politician.getTotalDaysServedParliament() / 365);
-		final Label expValue = new Label(
-				"Goverment: " + govYears + "y, Party: " + partyYears + "y, Parliament: " + parliamentYears + "y");
-		expValue.addStyleName("card-experience-value");
-
-		experienceLayout.addComponents(expIcon, expLabel, expValue);
-		statsContainer.addComponent(experienceLayout);
-
-		// Add the statsContainer to the cardContent
-		cardContent.addComponent(statsContainer);
-
-		// Create grid for the four sections
-		final HorizontalLayout sectionsGrid = new HorizontalLayout();
-		sectionsGrid.setSpacing(true);
-		sectionsGrid.setWidth("100%");
-
-		// Add the four main sections
-		final VerticalLayout politicalRoleLayout = CardInfoRowUtil.createSectionLayout("Political Role & Influence");
-		addPoliticalRoleMetrics(politicalRoleLayout, govMember, politician, ballotSummary, experienceSummary);
-		sectionsGrid.addComponent(politicalRoleLayout);
-
-		final VerticalLayout performanceLayout = CardInfoRowUtil.createSectionLayout("Parliamentary Performance");
-		politicianLeaderboardUtil.addParliamentaryPerformanceMetrics(performanceLayout, politician, ballotSummary);
-		sectionsGrid.addComponent(performanceLayout);
-
-	    cardContent.addComponent(sectionsGrid);
-
-		final HorizontalLayout sections2Grid = new HorizontalLayout();
-		sections2Grid.setSpacing(true);
-		sections2Grid.setWidth("100%");
-
-
-		final VerticalLayout legislativeLayout = CardInfoRowUtil.createSectionLayout("Legislative Activity");
-		politicianLeaderboardUtil.addLegislativeMetrics(legislativeLayout, politician);
-		sections2Grid.addComponent(legislativeLayout);
-
-		final VerticalLayout alignmentLayout = CardInfoRowUtil.createSectionLayout("Party Alignment");
-		politicianLeaderboardUtil.addPartyAlignmentMetrics(alignmentLayout, politician, ballotSummary);
-		sections2Grid.addComponent(alignmentLayout);
-		cardContent.addComponent(sections2Grid);
-
-		politicianLeaderboardUtil.addMinistryRoleSummary(cardContent, govMember, governmentBodyByMinistry, reportByMinistry);
-
-		return cardPanel;
-	}
-
-
-	/**
-	 * Adds the political role metrics.
-	 *
-	 * @param layout the layout
-	 * @param govMember the gov member
-	 * @param politician the politician
-	 * @param ballotSummary the ballot summary
-	 * @param experienceSummary
-	 */
-	private void addPoliticalRoleMetrics(VerticalLayout layout, ViewRiksdagenGovermentRoleMember govMember,
-			ViewRiksdagenPolitician politician, ViewRiksdagenPoliticianBallotSummary ballotSummary, ViewRiksdagenPoliticianExperienceSummary experienceSummary) {
-
-		layout.addComponent(CardInfoRowUtil.createInfoRow("Current Role:", govMember.getRoleCode(), VaadinIcons.INSTITUTION,
-				"Current position in parliament"));
-			layout.addComponent(CardInfoRowUtil.createInfoRow("Career Length:",
-				String.format(Locale.ENGLISH,"%,d days", govMember.getTotalDaysServed()),
-				VaadinIcons.TIMER, "Years in parliament"));
-			layout.addComponent(CardInfoRowUtil.createInfoRow("Total Propositions:",
-					String.format(Locale.ENGLISH,"%,d", govMember.getTotalPropositions()),
-					VaadinIcons.GROUP, "Total Propositions"));
-			layout.addComponent(CardInfoRowUtil.createInfoRow("Total Government Bills:",
-					String.format(Locale.ENGLISH,"%,d", govMember.getTotalGovernmentBills()),
-					VaadinIcons.GROUP, "Total Government Bills"));
-
-			politicianLeaderboardUtil.addTopRoles(layout, experienceSummary);
-			politicianLeaderboardUtil.addKnowledgeAreas(layout, experienceSummary);
-			politicianLeaderboardUtil.addExperienceMetrics(layout,experienceSummary);
-			politicianLeaderboardUtil.addPoliticalAnalysisComment(layout, experienceSummary);
-
 	}
 
 	/**

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRankingCurrentPartiesLeaderScoreboardPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/party/pagemode/PartyRankingCurrentPartiesLeaderScoreboardPageModContentFactoryImpl.java
@@ -41,6 +41,7 @@ import com.hack23.cia.service.external.esv.api.EsvApi;
 import com.hack23.cia.service.external.esv.api.GovernmentBodyAnnualOutcomeSummary;
 import com.hack23.cia.service.external.esv.api.GovernmentBodyAnnualSummary;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
+import com.hack23.cia.web.impl.ui.application.util.LeaderCardUtil;
 import com.hack23.cia.web.impl.ui.application.util.PartyLeaderUtil;
 import com.hack23.cia.web.impl.ui.application.views.common.pagemode.CardInfoRowUtil;
 import com.hack23.cia.web.impl.ui.application.views.common.pagemode.PoliticianLeaderboardUtil;
@@ -79,6 +80,9 @@ public final class PartyRankingCurrentPartiesLeaderScoreboardPageModContentFacto
 
 	@Autowired
 	private PoliticianLeaderboardUtil politicianLeaderboardUtil;
+
+	@Autowired
+	private LeaderCardUtil leaderCardUtil;
 
 	/**
 	 * Instantiates a new party ranking current parties leader scoreboard page mod content factory impl.
@@ -119,7 +123,7 @@ public final class PartyRankingCurrentPartiesLeaderScoreboardPageModContentFacto
 		final ResponsiveRow row = RowUtil.createGridLayout(wrapper);
 		row.setSizeFull();
 
-		final Map<String, ViewRiksdagenPolitician> politicianMap = loadPoliticiansByPersonId();
+		final Map<String, ViewRiksdagenPolitician> politicianMap = leaderCardUtil.loadPoliticiansByPersonId(getApplicationManager());
 		final Map<String, Boolean> partyLeaderMap = PartyLeaderUtil.computePartyLeaders(getApplicationManager(), politicianMap.keySet());
 
 		final List<ViewRiksdagenPolitician> partyLeaders = politicianMap.values().stream()
@@ -152,7 +156,7 @@ public final class PartyRankingCurrentPartiesLeaderScoreboardPageModContentFacto
 					.getDataContainer(ViewRiksdagenPoliticianBallotSummary.class).load(leader.getPersonId());
 		    final ViewRiksdagenPoliticianExperienceSummary experienceSummary = getApplicationManager().getDataContainer(ViewRiksdagenPoliticianExperienceSummary.class).load(leader.getPersonId());
 
-			final Panel cardPanel = createLeaderCard(leader, ballotSummary, governmentBodyByMinistry, reportByMinistry,experienceSummary);
+			final Panel cardPanel = leaderCardUtil.createLeaderCard(getApplicationManager(), leader, ballotSummary, governmentBodyByMinistry, reportByMinistry, experienceSummary);
 			row.addColumn().withDisplayRules(12, 6, 4, 4).withComponent(cardPanel);
 		}
 
@@ -160,237 +164,6 @@ public final class PartyRankingCurrentPartiesLeaderScoreboardPageModContentFacto
 				parameters, pageId);
 
 		return panelContent;
-	}
-
-	/**
-	 * Load politicians by person id.
-	 *
-	 * @return the map
-	 */
-	private Map<String, ViewRiksdagenPolitician> loadPoliticiansByPersonId() {
-		final DataContainer<ViewRiksdagenPolitician, String> politicianDataContainer = getApplicationManager()
-				.getDataContainer(ViewRiksdagenPolitician.class);
-
-		final List<ViewRiksdagenPolitician> activePoliticians = politicianDataContainer.findListByProperty(
-				new Object[] { Boolean.TRUE }, ViewRiksdagenPolitician_.active);
-
-		return activePoliticians.stream().collect(Collectors.toMap(ViewRiksdagenPolitician::getPersonId, p -> p));
-	}
-
-	/**
-	 * Creates the leader card.
-	 *
-	 * @param leader the leader
-	 * @param ballotSummary the ballot summary
-	 * @param governmentBodyByMinistry the government body by ministry
-	 * @param reportByMinistry the report by ministry
-	 * @param experienceSummary
-	 * @return the panel
-	 */
-	private Panel createLeaderCard(final ViewRiksdagenPolitician leader, final ViewRiksdagenPoliticianBallotSummary ballotSummary,
-			final Map<String, List<GovernmentBodyAnnualSummary>> governmentBodyByMinistry,
-			final Map<String, List<GovernmentBodyAnnualOutcomeSummary>> reportByMinistry, final ViewRiksdagenPoliticianExperienceSummary experienceSummary) {
-
-		final Panel cardPanel = new Panel();
-		cardPanel.addStyleName("leader-baseball-card");
-		cardPanel.setSizeFull();
-		Responsive.makeResponsive(cardPanel);
-
-		final VerticalLayout cardContent = new VerticalLayout();
-		cardContent.setMargin(true);
-		cardContent.setSpacing(true);
-		cardContent.setSizeFull();
-		cardPanel.setContent(cardContent);
-
-		CardInfoRowUtil.createCardHeader(cardContent,"Partiledare " + leader.getFirstName() + " " + leader.getLastName() + " ("
-				+ leader.getParty() + ")");
-
-		// Politician detail link
-		cardContent.addComponent(getPageLinkFactory().createPoliticianPageLink(leader));
-
-		// Party link
-		final Link partyLink = new Link("Party " + leader.getParty(),
-				new ExternalResource("#!" + UserViews.PARTY_VIEW_NAME + "/" + leader.getParty()));
-		partyLink.setIcon(VaadinIcons.GROUP);
-		cardContent.addComponent(partyLink);
-
-		final boolean isPartyLeader = PartyLeaderUtil.isPartyLeader(getApplicationManager(), leader.getPersonId());
-		if (isPartyLeader) {
-			final ViewRiksdagenPartyRoleMember leaderRole = PartyLeaderUtil.getPartyLeaderRole(getApplicationManager(), leader.getPersonId());
-			if (leaderRole != null) {
-				final Label subHeader = new Label("Partiledare (" + leader.getParty() + ") since " + leaderRole.getFromDate());
-				subHeader.addStyleName("card-subtitle");
-				cardContent.addComponent(subHeader);
-			}
-		}
-
-		// Government or not
-		ViewRiksdagenGovermentRoleMember govMember = null;
-		if (leader.isActiveGovernment()) {
-			final Label govLabel = new Label("Currently in Government");
-			govLabel.addStyleName("card-subtitle");
-			cardContent.addComponent(govLabel);
-
-			// Add ministry summary if we can identify their ministry
-			// The ministry detail is stored in the same structure as the ministry snippet:
-			// We need to find which ministry they belong to
-			// In the ministry snippet, "govMember.getDetail()" gives ministry detail key.
-			// Here we only have leader, not govMember. We must find a corresponding approach:
-
-			// Let's assume we can identify the leader's ministry from active government roles data:
-			// we do similar approach: load active government role members and find the one matching this leader
-			final ViewRiksdagenPolitician pol = leader; // same as leader
-			govMember = findGovernmentRoleForLeader(pol);
-			if (govMember != null) {
-				politicianLeaderboardUtil.addMinistryRoleSummary(cardContent, govMember, governmentBodyByMinistry, reportByMinistry);
-			}
-
-		} else {
-			final Label nonGovLabel = new Label("Not in Government");
-			nonGovLabel.addStyleName("card-subtitle-nongov");
-			cardContent.addComponent(nonGovLabel);
-		}
-
-		// Tenure and Experience rows
-		final VerticalLayout statsContainer = new VerticalLayout();
-		statsContainer.setSpacing(false);
-		statsContainer.addStyleName("card-stats-container");
-		statsContainer.setWidth("100%");
-
-		// Tenure (assuming leader might have totalDaysServed property)
-		final Label tenureIcon = new Label(VaadinIcons.CLOCK.getHtml(), ContentMode.HTML);
-		tenureIcon.setDescription("Total Tenure");
-		final Label tenureLabel = new Label("Tenure:");
-		tenureLabel.addStyleName("card-tenure-text");
-		final Label tenureValue = new Label(leader.getTotalDaysServedParty() + " days");
-		tenureValue.addStyleName("card-tenure-value");
-		final HorizontalLayout tenureLayout = new HorizontalLayout(tenureIcon, tenureLabel, tenureValue);
-		tenureLayout.setSpacing(true);
-		tenureLayout.addStyleName("card-tenure");
-		statsContainer.addComponent(tenureLayout);
-
-		// Experience
-		final HorizontalLayout experienceLayout = new HorizontalLayout();
-		experienceLayout.setSpacing(true);
-		experienceLayout.addStyleName("card-experience-section");
-		final Label expIcon = new Label(VaadinIcons.USER_CHECK.getHtml(), ContentMode.HTML);
-		expIcon.setDescription("Political Experience");
-		final Label expLabel = new Label("Experience:");
-		expLabel.addStyleName("card-experience-text");
-
-		final int govYears = (int) (leader.getTotalDaysServedGovernment() / 365);
-		final int partyYears = (int) (leader.getTotalDaysServedParty() / 365);
-		final int parliamentYears = (int) (leader.getTotalDaysServedParliament() / 365);
-		final String expText = String.format(Locale.ENGLISH, "Government: %dy, Party: %dy, Parliament: %dy",
-				govYears, partyYears, parliamentYears);
-		final Label expValue = new Label(expText);
-		expValue.addStyleName("card-experience-value");
-		experienceLayout.addComponents(expIcon, expLabel, expValue);
-		statsContainer.addComponent(experienceLayout);
-
-		cardContent.addComponent(statsContainer);
-
-		// Create grid for the four sections
-		final HorizontalLayout sectionsGrid = new HorizontalLayout();
-		sectionsGrid.setSpacing(true);
-		sectionsGrid.setWidth("100%");
-
-
-		// Add the four main sections
-		final VerticalLayout politicalRoleLayout = CardInfoRowUtil.createSectionLayout("Political Role & Influence");
-		addPoliticalRoleMetrics(politicalRoleLayout, PartyLeaderUtil.getPartyLeaderRole(getApplicationManager(), leader.getPersonId()), govMember, leader, ballotSummary,experienceSummary);
-		sectionsGrid.addComponent(politicalRoleLayout);
-
-		final VerticalLayout performanceLayout = CardInfoRowUtil.createSectionLayout("Parliamentary Performance");
-		politicianLeaderboardUtil.addParliamentaryPerformanceMetrics(performanceLayout, leader, ballotSummary);
-		sectionsGrid.addComponent(performanceLayout);
-
-	    cardContent.addComponent(sectionsGrid);
-
-		final HorizontalLayout sections2Grid = new HorizontalLayout();
-		sections2Grid.setSpacing(true);
-		sections2Grid.setWidth("100%");
-
-
-		final VerticalLayout legislativeLayout = CardInfoRowUtil.createSectionLayout("Legislative Activity");
-		politicianLeaderboardUtil.addLegislativeMetrics(legislativeLayout, leader);
-		sections2Grid.addComponent(legislativeLayout);
-
-		final VerticalLayout alignmentLayout = CardInfoRowUtil.createSectionLayout("Party Alignment");
-		politicianLeaderboardUtil.addPartyAlignmentMetrics(alignmentLayout, leader, ballotSummary);
-		sections2Grid.addComponent(alignmentLayout);
-		cardContent.addComponent(sections2Grid);
-
-		return cardPanel;
-	}
-
-	/**
-	 * Find government role for leader.
-	 *
-	 * @param leader the leader
-	 * @return the view riksdagen goverment role member
-	 */
-	private ViewRiksdagenGovermentRoleMember findGovernmentRoleForLeader(ViewRiksdagenPolitician leader) {
-		// Similar to ministry snippet loadActiveGovernmentRoleMembers:
-		final DataContainer<ViewRiksdagenGovermentRoleMember, String> govermentRoleMemberDataContainer = getApplicationManager()
-				.getDataContainer(ViewRiksdagenGovermentRoleMember.class);
-		final List<ViewRiksdagenGovermentRoleMember> activeGovMembers = govermentRoleMemberDataContainer.findListByProperty(
-				new Object[] { Boolean.TRUE }, ViewRiksdagenGovermentRoleMember_.active);
-
-		// Find the government role that matches this leader's personId
-		return activeGovMembers.stream()
-				.filter(govMember -> govMember.getPersonId().equals(leader.getPersonId()))
-				.findFirst().orElse(null);
-	}
-
-
-
-	/**
-	 * Adds the political role metrics.
-	 *
-	 * @param layout the layout
-	 * @param riksdagenPartyRoleMember the riksdagen party role member
-	 * @param govMember the gov member
-	 * @param politician the politician
-	 * @param ballotSummary the ballot summary
-	 * @param experienceSummary
-	 */
-	private void addPoliticalRoleMetrics(VerticalLayout layout, ViewRiksdagenPartyRoleMember riksdagenPartyRoleMember, ViewRiksdagenGovermentRoleMember govMember,
-			ViewRiksdagenPolitician politician, ViewRiksdagenPoliticianBallotSummary ballotSummary, ViewRiksdagenPoliticianExperienceSummary experienceSummary) {
-
-		addPartyExperince(layout, riksdagenPartyRoleMember, govMember, politician);
-
-        // Top Roles
-		politicianLeaderboardUtil.addTopRoles(layout, experienceSummary);
-
-		// Top Knowledge Areas
-		politicianLeaderboardUtil.addKnowledgeAreas(layout, experienceSummary);
-
-		politicianLeaderboardUtil.addExperienceMetrics(layout,experienceSummary);
-
-		politicianLeaderboardUtil.addPoliticalAnalysisComment(layout, experienceSummary);
-
-	}
-
-	private void addPartyExperince(VerticalLayout layout, ViewRiksdagenPartyRoleMember riksdagenPartyRoleMember,
-			ViewRiksdagenGovermentRoleMember govMember, ViewRiksdagenPolitician politician) {
-		if (govMember != null) {
-			layout.addComponent(CardInfoRowUtil.createInfoRow("Role:", govMember != null ? govMember.getRoleCode() : "N/A", VaadinIcons.INSTITUTION,
-					"Current position in Government"));
-			layout.addComponent(CardInfoRowUtil.createInfoRow("Career Length Government:",
-					String.format(Locale.ENGLISH,"%,d days", govMember != null ? govMember.getTotalDaysServed() : 0),
-					VaadinIcons.TIMER, "Years in Government"));
-	    } else {
-			layout.addComponent(CardInfoRowUtil.createInfoRow("Career Length Parlimanet:",
-					String.format(Locale.ENGLISH,"%,d days", politician != null ? politician.getTotalDaysServedParliament() : 0),
-					VaadinIcons.TIMER, "Years in Parlimanet"));
-	    }
-
-		layout.addComponent(CardInfoRowUtil.createInfoRow("Current Party Role:", riksdagenPartyRoleMember != null ? riksdagenPartyRoleMember.getRoleCode() : "N/A", VaadinIcons.INSTITUTION,
-				"Current position in Party"));
-		layout.addComponent(CardInfoRowUtil.createInfoRow("Career Length Party Leader:",
-				String.format(Locale.ENGLISH,"%,d days", riksdagenPartyRoleMember != null ? riksdagenPartyRoleMember.getTotalDaysServed() : 0),
-				VaadinIcons.TIMER, "Years as Party Leader"));
 	}
 
 	/**


### PR DESCRIPTION
Refactor `MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModContentFactoryImpl` to use `LeaderCardUtil` for creating leader cards and loading politicians.

* Add `LeaderCardUtil` class with methods for creating leader cards, loading politicians, and government role members.
* Remove duplicated methods for creating leader cards and loading politicians from `MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModContentFactoryImpl`.
* Update dependencies in `MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModContentFactoryImpl` to use `LeaderCardUtil`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/cia/pull/6966?shareId=75144332-210e-4bca-b0f5-acdcb7348d1d).