### PR TITLE
Add missing module-info.java files

### DIFF
--- a/model.external.worldbank.topic.impl/src/main/java/module-info.java
+++ b/model.external.worldbank.topic.impl/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+open module com.hack23.cia.model.external.worldbank.topic.impl {
+    exports com.hack23.cia.model.external.worldbank.topic.impl;
+
+    requires com.hack23.model.common.api;
+    requires java.xml.bind;
+    requires java.persistence;
+    requires org.hibernate.orm.jpamodelgen;
+    requires org.slf4j;
+    requires org.apache.commons.lang3;
+    requires jaxb2.basics.runtime;
+}

--- a/model.internal.application.user.impl/src/main/java/module-info.java
+++ b/model.internal.application.user.impl/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+open module com.hack23.cia.model.internal.application.user.impl {
+    exports com.hack23.cia.model.internal.application.user.impl;
+
+    requires com.hack23.model.common.api;
+    requires java.xml.bind;
+    requires java.persistence;
+    requires org.hibernate.orm.jpamodelgen;
+    requires org.slf4j;
+    requires org.apache.commons.lang3;
+    requires jaxb2.basics.runtime;
+}


### PR DESCRIPTION
Add `module-info.java` files for `model.external.worldbank.topic.impl` and `model.internal.application.user.impl`.

* **model.external.worldbank.topic.impl**
  - Declare the module name as `com.hack23.cia.model.external.worldbank.topic.impl`
  - Export the package `com.hack23.cia.model.external.worldbank.topic.impl`
  - Include required modules based on `pom.xml` such as `com.hack23.model.common.api`, `java.xml.bind`, `java.persistence`, `org.hibernate.orm.jpamodelgen`, `org.slf4j`, `org.apache.commons.lang3`, `jaxb2.basics.runtime`

* **model.internal.application.user.impl**
  - Declare the module name as `com.hack23.cia.model.internal.application.user.impl`
  - Export the package `com.hack23.cia.model.internal.application.user.impl`
  - Include required modules based on `pom.xml` such as `com.hack23.model.common.api`, `java.xml.bind`, `java.persistence`, `org.hibernate.orm.jpamodelgen`, `org.slf4j`, `org.apache.commons.lang3`, `jaxb2.basics.runtime`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/cia/pull/6971?shareId=f12730fe-fd30-4f3d-b723-3acb9c76b319).