### PR TITLE
Add Javadoc documentation for module-info.java files

### DIFF
--- a/citizen-intelligence-agency/src/main/java/module-info.java
+++ b/citizen-intelligence-agency/src/main/java/module-info.java
@@ -1,6 +1,23 @@
 /**
  * CIA (Citizen Intelligence Agency) Web Module.
- * 
+ *
+ * <p>This module delivers the Vaadin-based user interface, enabling users to
+ * explore political data, perform analyses, and manage administrative operations.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Vaadin UI for interactive dashboards</li>
+ *   <li>Spring Security integration</li>
+ *   <li>Responsive layouts and charting</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Vaadin for UI components</li>
+ *   <li>Spring Framework for security and backend integration</li>
+ *   <li>Third-party libraries for PDF viewing, charting, and user-agent parsing</li>
+ * </ul>
+ *
  * <p>This module implements the web interface for the CIA application using Vaadin framework.
  * It provides a comprehensive user interface for monitoring political figures, institutions,
  * and analyzing political/financial trends.</p>

--- a/model.external.riksdagen.documentcontent.impl/src/main/java/module-info.java
+++ b/model.external.riksdagen.documentcontent.impl/src/main/java/module-info.java
@@ -1,3 +1,24 @@
+/**
+ * Riksdagen Document Content Module.
+ *
+ * <p>This module provides implementation for handling document content from Riksdagen.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Fetching and parsing document content</li>
+ *   <li>Data transformation and storage</li>
+ *   <li>Integration with other Riksdagen modules</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Java Persistence API (JPA)</li>
+ *   <li>Hibernate ORM</li>
+ *   <li>SLF4J for logging</li>
+ * </ul>
+ *
+ * @see com.hack23.cia.model.common.api
+ */
 open module com.hack23.cia.model.external.riksdagen.documentcontent.impl {
 	exports com.hack23.cia.model.external.riksdagen.documentcontent.impl;
 	

--- a/model.external.riksdagen.dokumentlista.impl/src/main/java/module-info.java
+++ b/model.external.riksdagen.dokumentlista.impl/src/main/java/module-info.java
@@ -1,3 +1,24 @@
+/**
+ * Riksdagen Document List Module.
+ *
+ * <p>This module provides implementation for handling the document list from Riksdagen.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Fetching and parsing document lists</li>
+ *   <li>Data transformation and storage</li>
+ *   <li>Integration with other Riksdagen modules</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Java Persistence API (JPA)</li>
+ *   <li>Hibernate ORM</li>
+ *   <li>SLF4J for logging</li>
+ * </ul>
+ *
+ * @see com.hack23.cia.model.common.api
+ */
 open module com.hack23.cia.model.external.riksdagen.dokumentlista.impl {
 	exports com.hack23.cia.model.external.riksdagen.dokumentlista.impl;
 	

--- a/model.external.riksdagen.dokumentstatus.impl/src/main/java/module-info.java
+++ b/model.external.riksdagen.dokumentstatus.impl/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/**
+ * CIA (Citizen Intelligence Agency) Riksdagen Dokumentstatus Model Module.
+ *
+ * <p>This module includes data structures for Swedish Parliament document statuses,
+ * detailing the publication and progression of parliamentary documents.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Document status tracking</li>
+ *   <li>JPA mappings for parliamentary document entities</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Hibernate for object-relational mapping</li>
+ *   <li>XML-based data binding</li>
+ * </ul>
+ */
 open module com.hack23.cia.model.external.riksdagen.dokumentstatus.impl {
 	exports com.hack23.cia.model.external.riksdagen.dokumentstatus.impl;
 	

--- a/model.external.riksdagen.person.impl/src/main/java/module-info.java
+++ b/model.external.riksdagen.person.impl/src/main/java/module-info.java
@@ -1,3 +1,24 @@
+/**
+ * Riksdagen Person Module.
+ *
+ * <p>This module provides implementation for handling individual person data from Riksdagen.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Fetching and parsing person data</li>
+ *   <li>Data transformation and storage</li>
+ *   <li>Integration with other Riksdagen modules</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Java Persistence API (JPA)</li>
+ *   <li>Hibernate ORM</li>
+ *   <li>SLF4J for logging</li>
+ * </ul>
+ *
+ * @see com.hack23.cia.model.common.api
+ */
 open module com.hack23.cia.model.external.riksdagen.person.impl {
 	exports com.hack23.cia.model.external.riksdagen.person.impl;
 	

--- a/model.external.riksdagen.personlista.impl/src/main/java/module-info.java
+++ b/model.external.riksdagen.personlista.impl/src/main/java/module-info.java
@@ -1,3 +1,24 @@
+/**
+ * Riksdagen Person List Module.
+ *
+ * <p>This module provides implementation for handling the person list from Riksdagen.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Fetching and parsing person lists</li>
+ *   <li>Data transformation and storage</li>
+ *   <li>Integration with other Riksdagen modules</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Java Persistence API (JPA)</li>
+ *   <li>Hibernate ORM</li>
+ *   <li>SLF4J for logging</li>
+ * </ul>
+ *
+ * @see com.hack23.cia.model.common.api
+ */
 open module com.hack23.cia.model.external.riksdagen.personlista.impl {
 	exports com.hack23.cia.model.external.riksdagen.personlista.impl;
 	
@@ -10,6 +31,4 @@ open module com.hack23.cia.model.external.riksdagen.personlista.impl {
 	requires org.slf4j;
 	requires org.apache.commons.lang3;
 	requires jaxb2.basics.runtime;
-
-
 }

--- a/model.external.riksdagen.utskottsforslag.impl/src/main/java/module-info.java
+++ b/model.external.riksdagen.utskottsforslag.impl/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/**
+ * CIA (Citizen Intelligence Agency) Riksdagen Utskottsförslag Model Module.
+ *
+ * <p>This module manages committee proposals (utskottsförslag) from the Swedish
+ * Parliament, detailing recommended actions and decisions.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Utskottsförslag entity mappings</li>
+ *   <li>Structured representation of committee proposals</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Hibernate ORM for persistence</li>
+ *   <li>HyperJAXB/Java XML Binding</li>
+ * </ul>
+ */
 open module com.hack23.cia.model.external.riksdagen.utskottsforslag.impl {
 	exports com.hack23.cia.model.external.riksdagen.utskottsforslag.impl;
 	

--- a/model.external.riksdagen.votering.impl/src/main/java/module-info.java
+++ b/model.external.riksdagen.votering.impl/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/**
+ * CIA (Citizen Intelligence Agency) Riksdagen Votering Model Module.
+ *
+ * <p>This module defines data structures for individual voting records (votering)
+ * in the Swedish Parliament, allowing analysis of how members voted.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>JPA entities for votering data</li>
+ *   <li>Integration with the CIA model framework</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Hibernate-based persistence</li>
+ *   <li>JAXB for XML handling</li>
+ * </ul>
+ */
 open module com.hack23.cia.model.external.riksdagen.votering.impl {
 	exports com.hack23.cia.model.external.riksdagen.votering.impl;
 	

--- a/model.external.riksdagen.voteringlista.impl/src/main/java/module-info.java
+++ b/model.external.riksdagen.voteringlista.impl/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/**
+ * CIA (Citizen Intelligence Agency) Riksdagen Voteringlista Model Module.
+ *
+ * <p>This module models the voting list data from the Swedish Parliament,
+ * covering relevant entities and structures for parliamentary voting records.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Representation of detailed vote lists</li>
+ *   <li>JPA mappings for voteringlista entities</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Hibernate-based persistence</li>
+ *   <li>XML parsing with JAXB for data exchange</li>
+ * </ul>
+ */
 open module com.hack23.cia.model.external.riksdagen.voteringlista.impl {
 	exports com.hack23.cia.model.external.riksdagen.voteringlista.impl;
 	

--- a/model.external.val.kommunvalkrets.impl/src/main/java/module-info.java
+++ b/model.external.val.kommunvalkrets.impl/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/**
+ * CIA (Citizen Intelligence Agency) Val Kommunvalkrets Model Module.
+ *
+ * <p>This module contains the data structures to represent municipal electoral
+ * districts (kommunvalkrets) in Sweden.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Kommunvalkrets JPA entities</li>
+ *   <li>Integration with the CIA model framework</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Hibernate ORM for persistence</li>
+ *   <li>XML-based data mapping with JAXB</li>
+ * </ul>
+ */
 open module com.hack23.cia.model.external.val.kommunvalkrets.impl {
 	exports com.hack23.cia.model.external.val.kommunvalkrets.impl;
 	

--- a/model.external.val.landstingvalkrets.impl/src/main/java/module-info.java
+++ b/model.external.val.landstingvalkrets.impl/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/**
+ * CIA (Citizen Intelligence Agency) Val Landstingvalkrets Model Module.
+ *
+ * <p>This module contains data structures and JPA entities for representing
+ * Swedish county council electoral districts.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Mapping of landstingvalkrets (county council regions)</li>
+ *   <li>Integration with the CIA model framework</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Hibernate-based entity persistence</li>
+ *   <li>Java XML Binding for data import</li>
+ * </ul>
+ */
 open module com.hack23.cia.model.external.val.landstingvalkrets.impl {
 	exports com.hack23.cia.model.external.val.landstingvalkrets.impl;
 	

--- a/model.external.val.partier.impl/src/main/java/module-info.java
+++ b/model.external.val.partier.impl/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/**
+ * CIA (Citizen Intelligence Agency) Val Partier Model Module.
+ *
+ * <p>This module models Swedish political parties' data, covering official
+ * registrations and other party-related information.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Party entity definitions</li>
+ *   <li>Integration with the CIA model framework</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Hibernate-based persistence</li>
+ *   <li>JAXB for data import</li>
+ * </ul>
+ */
 open module com.hack23.cia.model.external.val.partier.impl {
 	exports com.hack23.cia.model.external.val.partier.impl;
 	

--- a/model.external.val.riksdagsvalkrets.impl/src/main/java/module-info.java
+++ b/model.external.val.riksdagsvalkrets.impl/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/**
+ * CIA (Citizen Intelligence Agency) Val Riksdagsvalkrets Model Module.
+ *
+ * <p>This module provides data structures for Swedish parliamentary constituencies
+ * (riksdagsvalkrets), enabling identification and mapping of these regions.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Riksdagsvalkrets entities and JPA mappings</li>
+ *   <li>Integration with the CIA model framework</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Hibernate ORM for data persistence</li>
+ *   <li>JAXB for XML-based data binding</li>
+ * </ul>
+ */
 open module com.hack23.cia.model.external.val.riksdagsvalkrets.impl {
 	exports com.hack23.cia.model.external.val.riksdagsvalkrets.impl;
 	

--- a/model.external.worldbank.countries.impl/src/main/java/module-info.java
+++ b/model.external.worldbank.countries.impl/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/**
+ * CIA (Citizen Intelligence Agency) World Bank Countries Data Model Module.
+ *
+ * <p>This module defines entities for World Bank country data, including metadata
+ * about nations, regions, and other related attributes.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Country data structures and JPA mappings</li>
+ *   <li>Integration with World Bank data sets</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Hibernate ORM for persistence</li>
+ *   <li>JAXB for XML-based data processing</li>
+ * </ul>
+ */
 open module com.hack23.cia.model.external.worldbank.countries.impl {
 	exports com.hack23.cia.model.external.worldbank.countries.impl;
 	

--- a/model.external.worldbank.data.impl/src/main/java/module-info.java
+++ b/model.external.worldbank.data.impl/src/main/java/module-info.java
@@ -1,3 +1,24 @@
+/**
+ * World Bank Data Module.
+ *
+ * <p>This module provides implementation for handling data from the World Bank.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Fetching and parsing data</li>
+ *   <li>Data transformation and storage</li>
+ *   <li>Integration with other World Bank modules</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Java Persistence API (JPA)</li>
+ *   <li>Hibernate ORM</li>
+ *   <li>SLF4J for logging</li>
+ * </ul>
+ *
+ * @see com.hack23.cia.model.common.api
+ */
 open module com.hack23.cia.model.external.worldbank.data.impl {
 	exports com.hack23.cia.model.external.worldbank.data.impl;
 	

--- a/model.external.worldbank.indicators.impl/src/main/java/module-info.java
+++ b/model.external.worldbank.indicators.impl/src/main/java/module-info.java
@@ -1,3 +1,24 @@
+/**
+ * World Bank Indicators Module.
+ *
+ * <p>This module provides implementation for handling indicators data from the World Bank.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Fetching and parsing indicators data</li>
+ *   <li>Data transformation and storage</li>
+ *   <li>Integration with other World Bank modules</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Java Persistence API (JPA)</li>
+ *   <li>Hibernate ORM</li>
+ *   <li>SLF4J for logging</li>
+ * </ul>
+ *
+ * @see com.hack23.cia.model.common.api
+ */
 open module com.hack23.cia.model.external.worldbank.indicators.impl {
 	exports com.hack23.cia.model.external.worldbank.indicators.impl;
 	

--- a/model.external.worldbank.topic.impl/src/main/java/module-info.java
+++ b/model.external.worldbank.topic.impl/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/**
+ * CIA (Citizen Intelligence Agency) World Bank Topic Data Model Module.
+ *
+ * <p>This module defines the data structures for handling World Bank topic
+ * classifications, including metadata and domain objects.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Topic-based categorization of World Bank data</li>
+ *   <li>JPA persistence for topic entities</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Hibernate ORM for data mapping</li>
+ *   <li>Java XML Binding for XML-based data</li>
+ * </ul>
+ */
 open module com.hack23.cia.model.external.worldbank.topic.impl {
     exports com.hack23.cia.model.external.worldbank.topic.impl;
 

--- a/model.internal.application.user.impl/src/main/java/module-info.java
+++ b/model.internal.application.user.impl/src/main/java/module-info.java
@@ -1,3 +1,22 @@
+/**
+ * CIA (Citizen Intelligence Agency) Internal Application User Model Module.
+ *
+ * <p>This module defines and implements user-related entities including account,
+ * authentication, and security contexts within the CIA application.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>User management and authentication entities</li>
+ *   <li>DDD-style domain model design</li>
+ *   <li>Audit and version tracking</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>JPA/Hibernate for entity persistence</li>
+ *   <li>Slf4j for logging</li>
+ * </ul>
+ */
 open module com.hack23.cia.model.internal.application.user.impl {
     exports com.hack23.cia.model.internal.application.user.impl;
     exports com.hack23.cia.model.internal.application.system.impl;

--- a/service.component.agent.impl/src/main/java/module-info.java
+++ b/service.component.agent.impl/src/main/java/module-info.java
@@ -1,6 +1,23 @@
 /**
  * CIA (Citizen Intelligence Agency) Agent Implementation Module.
  *
+ * <p>This module handles data collection and background processing, retrieving
+ * information from multiple sources such as Riksdagen, Val, and the World Bank.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Automated data collection agents</li>
+ *   <li>JMS-based message handling</li>
+ *   <li>Transaction management with Spring</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Spring Framework for scheduling and dependency injection</li>
+ *   <li>JMS for asynchronous message processing</li>
+ *   <li>Integration with external data services</li>
+ * </ul>
+ *
  * <p>This module implements the data collection and processing agents for the CIA application.
  * It provides implementations for retrieving and processing data from multiple sources including
  * the Swedish Parliament (Riksdagen), Election Authority (Val), and World Bank.</p>

--- a/service.data.api/src/main/java/module-info.java
+++ b/service.data.api/src/main/java/module-info.java
@@ -1,6 +1,22 @@
 /**
  * CIA (Citizen Intelligence Agency) Data Service API Module.
  *
+ * <p>This module defines the standardized data service APIs for persistence
+ * and retrieval across the CIA application.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Database operation interfaces</li>
+ *   <li>Model integration for various government data</li>
+ *   <li>Transitive access to external data models</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Java Persistence API for ORM</li>
+ *   <li>Model classes for external data structures</li>
+ * </ul>
+ *
  * <p>This module defines the data service API for the CIA application, providing
  * interfaces for data persistence and retrieval operations. It serves as the primary
  * contract for database operations across the application.</p>

--- a/service.external.esv/src/main/java/module-info.java
+++ b/service.external.esv/src/main/java/module-info.java
@@ -1,47 +1,22 @@
 /**
  * CIA (Citizen Intelligence Agency) ESV (Swedish National Financial Management Authority) Service Module.
  *
- * <p>This module provides integration with ESV (Ekonomistyrningsverket) data services,
- * enabling access to Swedish government financial data and statistics. The module handles
- * data retrieval and processing from ESV's various data formats including Excel and CSV.</p>
- *
- * <p>The module exports two packages:</p>
- * <ul>
- *   <li>{@code com.hack23.cia.service.external.esv.api} - Public interfaces for ESV data access</li>
- *   <li>{@code com.hack23.cia.service.external.esv.impl} - Implementation of ESV service interfaces</li>
- * </ul>
+ * <p>This module integrates with ESV’s data services to provide financial statistics,
+ * budget data, and government spending information.</p>
  *
  * <p>Key Features:</p>
  * <ul>
- *   <li>Financial Data Processing
- *     <ul>
- *       <li>Excel file parsing (POI)</li>
- *       <li>CSV data processing</li>
- *       <li>XML data handling</li>
- *     </ul>
- *   </li>
- *   <li>Government Financial Statistics
- *     <ul>
- *       <li>Budget execution data</li>
- *       <li>Financial statements</li>
- *       <li>Economic indicators</li>
- *     </ul>
- *   </li>
+ *   <li>Excel and CSV file parsing for financial data</li>
+ *   <li>Statistics for budget execution and economic indicators</li>
+ *   <li>Comprehensive logging and Spring-based configuration</li>
  * </ul>
  *
- * <p>This module integrates with the common external service framework and provides
- * standardized access to ESV's financial data as part of the CIA's comprehensive
- * monitoring of government financial performance.</p>
- *
- * <p>Technical Implementation:</p>
+ * <p>Technologies / Integrations:</p>
  * <ul>
- *   <li>Uses Apache POI for Excel file processing</li>
- *   <li>Implements CSV parsing for data files</li>
- *   <li>Provides Spring-based configuration</li>
- *   <li>Includes comprehensive logging</li>
+ *   <li>Apache POI for Excel processing</li>
+ *   <li>Commons CSV for data import</li>
+ *   <li>Spring Framework for dependency injection</li>
  * </ul>
- *
- * @see com.hack23.cia.service.external.common
  */
 open module com.hack23.cia.service.external.esv {
 	exports com.hack23.cia.service.external.esv.api;

--- a/service.external.val/src/main/java/module-info.java
+++ b/service.external.val/src/main/java/module-info.java
@@ -1,55 +1,23 @@
 /**
  * CIA (Citizen Intelligence Agency) Val (Swedish Election Authority) Service Module.
  *
- * <p>This module provides integration with the Swedish Election Authority's (Valmyndigheten)
- * data services, enabling access to electoral district information, political party data,
- * and election-related statistics.</p>
- *
- * <p>The module exports two packages:</p>
- * <ul>
- *   <li>{@code com.hack23.cia.service.external.val.api} - Public interfaces for election data access</li>
- *   <li>{@code com.hack23.cia.service.external.val.impl} - Implementation of election service interfaces</li>
- * </ul>
- *
- * <p>Electoral Data Categories:</p>
- * <ul>
- *   <li>Electoral Districts
- *     <ul>
- *       <li>Parliamentary constituencies (Riksdagsvalkrets)</li>
- *       <li>Municipal districts (Kommunvalkrets)</li>
- *       <li>County council districts (Landstingvalkrets)</li>
- *     </ul>
- *   </li>
- *   <li>Political Parties
- *     <ul>
- *       <li>Party registration data</li>
- *       <li>Party information</li>
- *       <li>Electoral participation</li>
- *     </ul>
- *   </li>
- * </ul>
- *
- * <p>This module integrates with the common external service framework and provides
- * standardized access to election authority data as part of the CIA's comprehensive
- * political monitoring system.</p>
+ * <p>This module provides integration with the Swedish Election Authority's data and
+ * offers standardized access to electoral district information, party data, and
+ * election statistics.</p>
  *
  * <p>Key Features:</p>
  * <ul>
- *   <li>Complete electoral district mapping</li>
- *   <li>Political party registration tracking</li>
- *   <li>XML-based data processing</li>
- *   <li>Spring-managed service implementation</li>
+ *   <li>Electoral district mapping and details</li>
+ *   <li>Party registration and tracking</li>
+ *   <li>XML-based data retrieval and processing</li>
  * </ul>
  *
- * <p>The service supports analysis of:</p>
+ * <p>Technologies / Integrations:</p>
  * <ul>
- *   <li>Electoral geography and constituencies</li>
- *   <li>Political party presence and distribution</li>
- *   <li>Electoral system structure</li>
+ *   <li>Spring Framework for service implementation</li>
+ *   <li>SLF4J for logging</li>
+ *   <li>Common external service framework</li>
  * </ul>
- *
- * @see com.hack23.cia.service.external.common
- * @see com.hack23.cia.model.external.val
  */
 open module com.hack23.cia.service.external.val {
 	exports com.hack23.cia.service.external.val.api;

--- a/web-widgets/src/main/java/module-info.java
+++ b/web-widgets/src/main/java/module-info.java
@@ -1,3 +1,23 @@
+/**
+ * Web Widgets Module.
+ *
+ * <p>This module provides web widgets for the application.</p>
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Custom Vaadin components</li>
+ *   <li>Reusable UI elements</li>
+ *   <li>Integration with the main web module</li>
+ * </ul>
+ *
+ * <p>Technologies / Integrations:</p>
+ * <ul>
+ *   <li>Vaadin for UI components</li>
+ *   <li>Apache Commons Lang</li>
+ * </ul>
+ *
+ * @see com.hack23.cia.web
+ */
 open module com.hack23.cia.web.widgets {
 	exports com.hack23.cia.web.widgets.charts;
 	


### PR DESCRIPTION
Enhance module-info.java files with comprehensive Javadoc comments to describe the purpose, key features, and technologies used in each module. This improves code readability and provides better context for developers.