### PR TITLE
Remove unnecessary Maven profiles from devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -93,7 +93,6 @@
             "install",
             "-pl",
             "!com.hack23.cia:cia-dist-deb",
-            "-Prelease-site,all-modules",
             "-DforkMode=once",
             "-Dtest=!**ITest*,!**DocumentationTest*",
             "-Dmaven.test.failure.ignore=true",
@@ -118,7 +117,6 @@
             "install",
             "-pl",
             "!com.hack23.cia:cia-dist-deb,!com.hack23.cia:cia-dist-cloudformation",
-            "-Pall-modules",
             "-DskipTests",
             "-DfailIfNoTests=false",
             "-Dsurefire.failIfNoSpecifiedTests=false"


### PR DESCRIPTION
Eliminate redundant Maven profiles to streamline the development container setup.