### PR TITLE
Add test coverage for PageCommandUserConstants

### DIFF
--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/suites/IntegrationTestSuite.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/suites/IntegrationTestSuite.java
@@ -15,6 +15,14 @@ import com.hack23.cia.systemintegrationtest.admin.security.AdminSecurityTest;
 import com.hack23.cia.systemintegrationtest.ui.UserPageVisit;
 import com.hack23.cia.systemintegrationtest.ui.WebDriverFactory;
 import com.hack23.cia.systemintegrationtest.user.home.UserHomeTest;
+import com.hack23.cia.systemintegrationtest.user.party.UserPartyTest;
+import com.hack23.cia.systemintegrationtest.user.committee.UserCommitteeTest;
+import com.hack23.cia.systemintegrationtest.user.country.UserCountryTest;
+import com.hack23.cia.systemintegrationtest.user.ministry.UserMinistryTest;
+import com.hack23.cia.systemintegrationtest.user.governmentbody.UserGovernmentBodyTest;
+import com.hack23.cia.systemintegrationtest.user.parliament.UserParliamentTest;
+import com.hack23.cia.systemintegrationtest.user.politician.UserPoliticianTest;
+import com.hack23.cia.systemintegrationtest.user.document.UserDocumentTest;
 
 /**
  * The Class IntegrationTestSuite.
@@ -25,7 +33,15 @@ import com.hack23.cia.systemintegrationtest.user.home.UserHomeTest;
     AdminDataTest.class,
     AdminOperationsTest.class,
     AdminSecurityTest.class,
-    UserHomeTest.class
+    UserHomeTest.class,
+    UserPartyTest.class,
+    UserCommitteeTest.class,
+    UserCountryTest.class,
+    UserMinistryTest.class,
+    UserGovernmentBodyTest.class,
+    UserParliamentTest.class,
+    UserPoliticianTest.class,
+    UserDocumentTest.class
 })
 public class IntegrationTestSuite {
 

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/committee/UserCommitteeTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/committee/UserCommitteeTest.java
@@ -1,0 +1,25 @@
+package com.hack23.cia.systemintegrationtest.user.committee;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.hack23.cia.systemintegrationtest.AbstractUITest;
+import com.hack23.cia.systemintegrationtest.categories.IntegrationTest;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PageCommandCommitteeConstants;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PageCommandCommitteeRankingConstants;
+
+@Category(IntegrationTest.class)
+public final class UserCommitteeTest extends AbstractUITest {
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyCommitteePage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandCommitteeConstants.COMMAND_COMMITTEE);
+        pageVisit.validatePage(PageCommandCommitteeConstants.COMMAND_COMMITTEE);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyCommitteeRankingPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandCommitteeRankingConstants.COMMAND_COMMITTEE_RANKING);
+        pageVisit.validatePage(PageCommandCommitteeRankingConstants.COMMAND_COMMITTEE_RANKING);
+    }
+}

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/committee/UserCommitteeTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/committee/UserCommitteeTest.java
@@ -13,13 +13,31 @@ public final class UserCommitteeTest extends AbstractUITest {
 
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyCommitteePage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandCommitteeConstants.COMMAND_COMMITTEE);
-        pageVisit.validatePage(PageCommandCommitteeConstants.COMMAND_COMMITTEE);
+        pageVisit.visitDirectPage(PageCommandCommitteeConstants.COMMAND_COMMITTEES_BY_PARTY);
+        pageVisit.validatePage(PageCommandCommitteeConstants.COMMAND_COMMITTEES_BY_PARTY);
     }
 
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyCommitteeRankingPage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandCommitteeRankingConstants.COMMAND_COMMITTEE_RANKING);
-        pageVisit.validatePage(PageCommandCommitteeRankingConstants.COMMAND_COMMITTEE_RANKING);
+        pageVisit.visitDirectPage(PageCommandCommitteeRankingConstants.COMMAND_COMMITTEE_RANKING_DATAGRID);
+        pageVisit.validatePage(PageCommandCommitteeRankingConstants.COMMAND_COMMITTEE_RANKING_DATAGRID);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyCurrentCommitteesByPartyDaysServedPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandCommitteeConstants.COMMAND_CURRENT_COMMITTEES_BY_PARTY_DAYS_SERVED);
+        pageVisit.validatePage(PageCommandCommitteeConstants.COMMAND_CURRENT_COMMITTEES_BY_PARTY_DAYS_SERVED);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyChartsCurrentCommitteesPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandCommitteeConstants.COMMAND_CHARTS_CURRENT_COMMITTEES);
+        pageVisit.validatePage(PageCommandCommitteeConstants.COMMAND_CHARTS_CURRENT_COMMITTEES);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyAllCommitteesByHeadcountPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandCommitteeRankingConstants.COMMAND_ALL_COMMITTEES_BY_HEADCOUNT);
+        pageVisit.validatePage(PageCommandCommitteeRankingConstants.COMMAND_ALL_COMMITTEES_BY_HEADCOUNT);
     }
 }

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/country/UserCountryTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/country/UserCountryTest.java
@@ -1,0 +1,18 @@
+package com.hack23.cia.systemintegrationtest.user.country;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.hack23.cia.systemintegrationtest.AbstractUITest;
+import com.hack23.cia.systemintegrationtest.categories.IntegrationTest;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PageCommandCountryRankingConstants;
+
+@Category(IntegrationTest.class)
+public final class UserCountryTest extends AbstractUITest {
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyCountryRankingPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandCountryRankingConstants.COMMAND_COUNTRY_RANKING);
+        pageVisit.validatePage(PageCommandCountryRankingConstants.COMMAND_COUNTRY_RANKING);
+    }
+}

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/country/UserCountryTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/country/UserCountryTest.java
@@ -12,7 +12,31 @@ public final class UserCountryTest extends AbstractUITest {
 
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyCountryRankingPage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandCountryRankingConstants.COMMAND_COUNTRY_RANKING);
-        pageVisit.validatePage(PageCommandCountryRankingConstants.COMMAND_COUNTRY_RANKING);
+        pageVisit.visitDirectPage(PageCommandCountryRankingConstants.COUNTRY_RANKING_COMMAND_PAGEVISIT_HISTORY);
+        pageVisit.validatePage(PageCommandCountryRankingConstants.COUNTRY_RANKING_COMMAND_PAGEVISIT_HISTORY);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyCountryRankingOverviewPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandCountryRankingConstants.COUNTRY_RANKING_COMMAND_OVERVIEW);
+        pageVisit.validatePage(PageCommandCountryRankingConstants.COUNTRY_RANKING_COMMAND_OVERVIEW);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyCountryRankingDataGridPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandCountryRankingConstants.COUNTRY_RANKING_COMMAND_DATAGRID);
+        pageVisit.validatePage(PageCommandCountryRankingConstants.COUNTRY_RANKING_COMMAND_DATAGRID);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyCountryRankingChartsPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandCountryRankingConstants.COUNTRY_RANKING_COMMAND_CHARTS);
+        pageVisit.validatePage(PageCommandCountryRankingConstants.COUNTRY_RANKING_COMMAND_CHARTS);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyCountryRankingPageVisitHistoryPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandCountryRankingConstants.COUNTRY_RANKING_COMMAND_PAGEVISIT_HISTORY);
+        pageVisit.validatePage(PageCommandCountryRankingConstants.COUNTRY_RANKING_COMMAND_PAGEVISIT_HISTORY);
     }
 }

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/document/UserDocumentTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/document/UserDocumentTest.java
@@ -1,0 +1,26 @@
+package com.hack23.cia.systemintegrationtest.user.document;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.hack23.cia.systemintegrationtest.AbstractUITest;
+import com.hack23.cia.systemintegrationtest.categories.IntegrationTest;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PageCommandDocumentConstants;
+
+/**
+ * The Class UserDocumentTest.
+ */
+@Category(IntegrationTest.class)
+public final class UserDocumentTest extends AbstractUITest {
+
+    /**
+     * Verify document page.
+     *
+     * @throws Exception the exception
+     */
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyDocumentPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandDocumentConstants.COMMAND_DOCUMENT);
+        pageVisit.validatePage(PageCommandDocumentConstants.COMMAND_DOCUMENT);
+    }
+}

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/document/UserDocumentTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/document/UserDocumentTest.java
@@ -20,7 +20,51 @@ public final class UserDocumentTest extends AbstractUITest {
      */
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyDocumentPage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandDocumentConstants.COMMAND_DOCUMENT);
-        pageVisit.validatePage(PageCommandDocumentConstants.COMMAND_DOCUMENT);
+        pageVisit.visitDirectPage(PageCommandDocumentConstants.COMMAND_DOCUMENT_ACTIVITY);
+        pageVisit.validatePage(PageCommandDocumentConstants.COMMAND_DOCUMENT_ACTIVITY);
+    }
+
+    /**
+     * Verify document details page.
+     *
+     * @throws Exception the exception
+     */
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyDocumentDetailsPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandDocumentConstants.COMMAND_DOCUMENT_DETAILS);
+        pageVisit.validatePage(PageCommandDocumentConstants.COMMAND_DOCUMENT_DETAILS);
+    }
+
+    /**
+     * Verify document references page.
+     *
+     * @throws Exception the exception
+     */
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyDocumentReferencesPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandDocumentConstants.COMMAND_DOCUMENT_REFERENCES);
+        pageVisit.validatePage(PageCommandDocumentConstants.COMMAND_DOCUMENT_REFERENCES);
+    }
+
+    /**
+     * Verify documents page.
+     *
+     * @throws Exception the exception
+     */
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyDocumentsPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandDocumentConstants.COMMAND_DOCUMENTS);
+        pageVisit.validatePage(PageCommandDocumentConstants.COMMAND_DOCUMENTS);
+    }
+
+    /**
+     * Verify search document page.
+     *
+     * @throws Exception the exception
+     */
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifySearchDocumentPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandDocumentConstants.COMMAND_SEARCH_DOCUMENT);
+        pageVisit.validatePage(PageCommandDocumentConstants.COMMAND_SEARCH_DOCUMENT);
     }
 }

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/governmentbody/UserGovernmentBodyTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/governmentbody/UserGovernmentBodyTest.java
@@ -1,0 +1,25 @@
+package com.hack23.cia.systemintegrationtest.user.governmentbody;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.hack23.cia.systemintegrationtest.AbstractUITest;
+import com.hack23.cia.systemintegrationtest.categories.IntegrationTest;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PageCommandGovernmentBodyConstants;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PageCommandGovernmentBodyRankingConstants;
+
+@Category(IntegrationTest.class)
+public final class UserGovernmentBodyTest extends AbstractUITest {
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyGovernmentBodyPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY);
+        pageVisit.validatePage(PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyGovernmentBodyRankingPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODY_RANKING);
+        pageVisit.validatePage(PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODY_RANKING);
+    }
+}

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/governmentbody/UserGovernmentBodyTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/governmentbody/UserGovernmentBodyTest.java
@@ -13,13 +13,31 @@ public final class UserGovernmentBodyTest extends AbstractUITest {
 
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyGovernmentBodyPage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY);
-        pageVisit.validatePage(PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY);
+        pageVisit.visitDirectPage(PageCommandGovernmentBodyConstants.GOVERNMENT_BODY_COMMAND_EXPENDITURE);
+        pageVisit.validatePage(PageCommandGovernmentBodyConstants.GOVERNMENT_BODY_COMMAND_EXPENDITURE);
     }
 
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyGovernmentBodyRankingPage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODY_RANKING);
-        pageVisit.validatePage(PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODY_RANKING);
+        pageVisit.visitDirectPage(PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODY_RANKING_DATAGRID);
+        pageVisit.validatePage(PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODY_RANKING_DATAGRID);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyGovernmentBodyRankingOverviewPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODY_RANKING_OVERVIEW);
+        pageVisit.validatePage(PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODY_RANKING_OVERVIEW);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyGovernmentBodiesHeadcountPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODIES_HEADCOUNT);
+        pageVisit.validatePage(PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODIES_HEADCOUNT);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyGovernmentBodiesIncomePage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODIES_INCOME);
+        pageVisit.validatePage(PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODIES_INCOME);
     }
 }

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/home/UserHomeTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/home/UserHomeTest.java
@@ -327,5 +327,33 @@ public final class UserHomeTest extends AbstractUITest {
 
 	}
 
+	@Test(timeout = DEFAULT_TIMEOUT)
+	public void verifyAgencyPage() throws Exception {
+		pageVisit.visitDirectPage(PageCommandUserConstants.COMMAND_AGENCY);
+		pageVisit.validatePage(PageCommandUserConstants.COMMAND_AGENCY);
+	}
 
+	@Test(timeout = DEFAULT_TIMEOUT)
+	public void verifyApplicationConfigurationPage() throws Exception {
+		pageVisit.visitDirectPage(PageCommandUserConstants.COMMAND_APPLICATION_CONFIGURATION);
+		pageVisit.validatePage(PageCommandUserConstants.COMMAND_APPLICATION_CONFIGURATION);
+	}
+
+	@Test(timeout = DEFAULT_TIMEOUT)
+	public void verifyBallotOverviewPage() throws Exception {
+		pageVisit.visitDirectPage(PageCommandUserConstants.COMMAND_BALLOT_OVERVIEW);
+		pageVisit.validatePage(PageCommandUserConstants.COMMAND_BALLOT_OVERVIEW);
+	}
+
+	@Test(timeout = DEFAULT_TIMEOUT)
+	public void verifyMainViewOverviewPage() throws Exception {
+		pageVisit.visitDirectPage(PageCommandUserConstants.COMMAND_MAINVIEW_OVERVIEW);
+		pageVisit.validatePage(PageCommandUserConstants.COMMAND_MAINVIEW_OVERVIEW);
+	}
+
+	@Test(timeout = DEFAULT_TIMEOUT)
+	public void verifyMonitoringPage() throws Exception {
+		pageVisit.visitDirectPage(PageCommandUserConstants.COMMAND_MONITORING);
+		pageVisit.validatePage(PageCommandUserConstants.COMMAND_MONITORING);
+	}
 }

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/ministry/UserMinistryTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/ministry/UserMinistryTest.java
@@ -13,13 +13,31 @@ public final class UserMinistryTest extends AbstractUITest {
 
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyMinistryPage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandMinistryConstants.COMMAND_MINISTRY);
-        pageVisit.validatePage(PageCommandMinistryConstants.COMMAND_MINISTRY);
+        pageVisit.visitDirectPage(PageCommandMinistryConstants.MINISTRY_COMMAND_CHARTS_CURRENT_BY_HEADCOUNT);
+        pageVisit.validatePage(PageCommandMinistryConstants.MINISTRY_COMMAND_CHARTS_CURRENT_BY_HEADCOUNT);
     }
 
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyMinistryRankingPage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandMinistryRankingConstants.COMMAND_MINISTRY_RANKING);
-        pageVisit.validatePage(PageCommandMinistryRankingConstants.COMMAND_MINISTRY_RANKING);
+        pageVisit.visitDirectPage(PageCommandMinistryRankingConstants.COMMAND_MINISTRY_RANKING_DATAGRID);
+        pageVisit.validatePage(PageCommandMinistryRankingConstants.COMMAND_MINISTRY_RANKING_DATAGRID);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyMinistryRankingOverviewPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandMinistryRankingConstants.COMMAND_MINISTRY_RANKING_OVERVIEW);
+        pageVisit.validatePage(PageCommandMinistryRankingConstants.COMMAND_MINISTRY_RANKING_OVERVIEW);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyChartsCurrentMinistriesLeaderScoreboardPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandMinistryRankingConstants.COMMAND_CHARTS_CURRENT_MINISTRIES_LEADER_SCOREBOARD);
+        pageVisit.validatePage(PageCommandMinistryRankingConstants.COMMAND_CHARTS_CURRENT_MINISTRIES_LEADER_SCOREBOARD);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyChartsCurrentMinistriesByHeadcountPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandMinistryRankingConstants.COMMAND_CHARTS_CURRENT_MINISTRIES_BY_HEADCOUNT);
+        pageVisit.validatePage(PageCommandMinistryRankingConstants.COMMAND_CHARTS_CURRENT_MINISTRIES_BY_HEADCOUNT);
     }
 }

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/ministry/UserMinistryTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/ministry/UserMinistryTest.java
@@ -40,4 +40,10 @@ public final class UserMinistryTest extends AbstractUITest {
         pageVisit.visitDirectPage(PageCommandMinistryRankingConstants.COMMAND_CHARTS_CURRENT_MINISTRIES_BY_HEADCOUNT);
         pageVisit.validatePage(PageCommandMinistryRankingConstants.COMMAND_CHARTS_CURRENT_MINISTRIES_BY_HEADCOUNT);
     }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyAllMinistriesByHeadcountPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandMinistryRankingConstants.COMMAND_CHARTS_ALL_MINISTRIES_BY_HEADCOUNT);
+        pageVisit.validatePage(PageCommandMinistryRankingConstants.COMMAND_CHARTS_ALL_MINISTRIES_BY_HEADCOUNT);
+    }
 }

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/ministry/UserMinistryTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/ministry/UserMinistryTest.java
@@ -1,0 +1,25 @@
+package com.hack23.cia.systemintegrationtest.user.ministry;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.hack23.cia.systemintegrationtest.AbstractUITest;
+import com.hack23.cia.systemintegrationtest.categories.IntegrationTest;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PageCommandMinistryConstants;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PageCommandMinistryRankingConstants;
+
+@Category(IntegrationTest.class)
+public final class UserMinistryTest extends AbstractUITest {
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyMinistryPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandMinistryConstants.COMMAND_MINISTRY);
+        pageVisit.validatePage(PageCommandMinistryConstants.COMMAND_MINISTRY);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyMinistryRankingPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandMinistryRankingConstants.COMMAND_MINISTRY_RANKING);
+        pageVisit.validatePage(PageCommandMinistryRankingConstants.COMMAND_MINISTRY_RANKING);
+    }
+}

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/parliament/UserParliamentTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/parliament/UserParliamentTest.java
@@ -13,13 +13,31 @@ public final class UserParliamentTest extends AbstractUITest {
 
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyParliamentPage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandParliamentConstants.COMMAND_PARLIAMENT);
-        pageVisit.validatePage(PageCommandParliamentConstants.COMMAND_PARLIAMENT);
+        pageVisit.visitDirectPage(PageCommandParliamentConstants.COMMAND_PARLIAMENT_RANKING_OVERVIEW);
+        pageVisit.validatePage(PageCommandParliamentConstants.COMMAND_PARLIAMENT_RANKING_OVERVIEW);
     }
 
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyParliamentRankingPage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandParliamentRankingConstants.COMMAND_PARLIAMENT_RANKING);
-        pageVisit.validatePage(PageCommandParliamentRankingConstants.COMMAND_PARLIAMENT_RANKING);
+        pageVisit.visitDirectPage(PageCommandParliamentRankingConstants.COMMAND_PARLIAMENT_RANKING_OVERVIEW);
+        pageVisit.validatePage(PageCommandParliamentRankingConstants.COMMAND_PARLIAMENT_RANKING_OVERVIEW);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyRiskSummaryPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandParliamentRankingConstants.COMMAND_RISK_SUMMARY);
+        pageVisit.validatePage(PageCommandParliamentRankingConstants.COMMAND_RISK_SUMMARY);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyRuleViolationPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandParliamentRankingConstants.COMMAND_RULE_VIOLATION);
+        pageVisit.validatePage(PageCommandParliamentRankingConstants.COMMAND_RULE_VIOLATION);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyDocumentActivityPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandParliamentRankingConstants.COMMAND_DOCUMENT_ACTIVITY);
+        pageVisit.validatePage(PageCommandParliamentRankingConstants.COMMAND_DOCUMENT_ACTIVITY);
     }
 }

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/parliament/UserParliamentTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/parliament/UserParliamentTest.java
@@ -1,0 +1,25 @@
+package com.hack23.cia.systemintegrationtest.user.parliament;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.hack23.cia.systemintegrationtest.AbstractUITest;
+import com.hack23.cia.systemintegrationtest.categories.IntegrationTest;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PageCommandParliamentConstants;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PageCommandParliamentRankingConstants;
+
+@Category(IntegrationTest.class)
+public final class UserParliamentTest extends AbstractUITest {
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyParliamentPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandParliamentConstants.COMMAND_PARLIAMENT);
+        pageVisit.validatePage(PageCommandParliamentConstants.COMMAND_PARLIAMENT);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyParliamentRankingPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandParliamentRankingConstants.COMMAND_PARLIAMENT_RANKING);
+        pageVisit.validatePage(PageCommandParliamentRankingConstants.COMMAND_PARLIAMENT_RANKING);
+    }
+}

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/party/UserPartyTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/party/UserPartyTest.java
@@ -13,13 +13,31 @@ public final class UserPartyTest extends AbstractUITest {
 
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyPartyPage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandPartyConstants.COMMAND_PARTY);
-        pageVisit.validatePage(PageCommandPartyConstants.COMMAND_PARTY);
+        pageVisit.visitDirectPage(PageCommandPartyConstants.COMMAND_CHARTS_CURRENT_GOVERNMENT_PARTIES);
+        pageVisit.validatePage(PageCommandPartyConstants.COMMAND_CHARTS_CURRENT_GOVERNMENT_PARTIES);
     }
 
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyPartyRankingPage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandPartyRankingConstants.COMMAND_PARTY_RANKING);
-        pageVisit.validatePage(PageCommandPartyRankingConstants.COMMAND_PARTY_RANKING);
+        pageVisit.visitDirectPage(PageCommandPartyRankingConstants.PARTY_RANKING_COMMAND_DATAGRID);
+        pageVisit.validatePage(PageCommandPartyRankingConstants.PARTY_RANKING_COMMAND_DATAGRID);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyPartyWinnerPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandPartyConstants.COMMAND_CHARTS_PARTY_WINNER);
+        pageVisit.validatePage(PageCommandPartyConstants.COMMAND_CHARTS_PARTY_WINNER);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyPartyGenderPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandPartyConstants.COMMAND_CHARTS_PARTY_GENDER);
+        pageVisit.validatePage(PageCommandPartyConstants.COMMAND_CHARTS_PARTY_GENDER);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyPartyAgePage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandPartyConstants.COMMAND_CHARTS_PARTY_AGE);
+        pageVisit.validatePage(PageCommandPartyConstants.COMMAND_CHARTS_PARTY_AGE);
     }
 }

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/party/UserPartyTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/party/UserPartyTest.java
@@ -1,0 +1,25 @@
+package com.hack23.cia.systemintegrationtest.user.party;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.hack23.cia.systemintegrationtest.AbstractUITest;
+import com.hack23.cia.systemintegrationtest.categories.IntegrationTest;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PageCommandPartyConstants;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PageCommandPartyRankingConstants;
+
+@Category(IntegrationTest.class)
+public final class UserPartyTest extends AbstractUITest {
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyPartyPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandPartyConstants.COMMAND_PARTY);
+        pageVisit.validatePage(PageCommandPartyConstants.COMMAND_PARTY);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyPartyRankingPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandPartyRankingConstants.COMMAND_PARTY_RANKING);
+        pageVisit.validatePage(PageCommandPartyRankingConstants.COMMAND_PARTY_RANKING);
+    }
+}

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/politician/UserPoliticianTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/politician/UserPoliticianTest.java
@@ -12,7 +12,31 @@ public final class UserPoliticianTest extends AbstractUITest {
 
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyPoliticianRankingPage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandPoliticianRankingConstants.COMMAND_POLITICIAN_RANKING);
-        pageVisit.validatePage(PageCommandPoliticianRankingConstants.COMMAND_POLITICIAN_RANKING);
+        pageVisit.visitDirectPage(PageCommandPoliticianRankingConstants.POLITICIAN_RANKING_COMMAND_DATAGRID);
+        pageVisit.validatePage(PageCommandPoliticianRankingConstants.POLITICIAN_RANKING_COMMAND_DATAGRID);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyPoliticianRankingOverviewPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandPoliticianRankingConstants.POLITICIAN_RANKING_COMMAND_OVERVIEW);
+        pageVisit.validatePage(PageCommandPoliticianRankingConstants.POLITICIAN_RANKING_COMMAND_OVERVIEW);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyPoliticianRankingPageVisitHistoryPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandPoliticianRankingConstants.POLITICIAN_RANKING_COMMAND_PAGEVISIT_HISTORY);
+        pageVisit.validatePage(PageCommandPoliticianRankingConstants.POLITICIAN_RANKING_COMMAND_PAGEVISIT_HISTORY);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyPoliticianRankingChartsPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandPoliticianRankingConstants.POLITICIAN_RANKING_COMMAND_CHARTS);
+        pageVisit.validatePage(PageCommandPoliticianRankingConstants.POLITICIAN_RANKING_COMMAND_CHARTS);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyPoliticianRankingDataGridPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandPoliticianRankingConstants.POLITICIAN_RANKING_COMMAND_DATAGRID);
+        pageVisit.validatePage(PageCommandPoliticianRankingConstants.POLITICIAN_RANKING_COMMAND_DATAGRID);
     }
 }

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/politician/UserPoliticianTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/politician/UserPoliticianTest.java
@@ -1,0 +1,18 @@
+package com.hack23.cia.systemintegrationtest.user.politician;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.hack23.cia.systemintegrationtest.AbstractUITest;
+import com.hack23.cia.systemintegrationtest.categories.IntegrationTest;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PageCommandPoliticianRankingConstants;
+
+@Category(IntegrationTest.class)
+public final class UserPoliticianTest extends AbstractUITest {
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyPoliticianRankingPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandPoliticianRankingConstants.COMMAND_POLITICIAN_RANKING);
+        pageVisit.validatePage(PageCommandPoliticianRankingConstants.COMMAND_POLITICIAN_RANKING);
+    }
+}


### PR DESCRIPTION
Add new tests to the `IntegrationTestSuite` following the structure of existing tests and using constants from `PageCommandUserConstants`.

* **UserHomeTest**:
  - Add new test methods `verifyAgencyPage`, `verifyApplicationConfigurationPage`, `verifyBallotOverviewPage`, `verifyMainViewOverviewPage`, and `verifyMonitoringPage`.

* **UserPartyTest**:
  - Add new test class `UserPartyTest`.
  - Add new test methods `verifyPartyPage` and `verifyPartyRankingPage`.

* **UserCommitteeTest**:
  - Add new test class `UserCommitteeTest`.
  - Add new test methods `verifyCommitteePage` and `verifyCommitteeRankingPage`.

* **UserCountryTest**:
  - Add new test class `UserCountryTest`.
  - Add new test method `verifyCountryRankingPage`.

* **UserMinistryTest**:
  - Add new test class `UserMinistryTest`.
  - Add new test methods `verifyMinistryPage` and `verifyMinistryRankingPage`.

* **UserGovernmentBodyTest**:
  - Add new test class `UserGovernmentBodyTest`.
  - Add new test methods `verifyGovernmentBodyPage` and `verifyGovernmentBodyRankingPage`.

* **UserParliamentTest**:
  - Add new test class `UserParliamentTest`.
  - Add new test methods `verifyParliamentPage` and `verifyParliamentRankingPage`.

* **UserPoliticianTest**:
  - Add new test class `UserPoliticianTest`.
  - Add new test method `verifyPoliticianRankingPage`.

* **UserDocumentTest**:
  - Add new test class `UserDocumentTest`.
  - Add new test method `verifyDocumentPage`.

* **IntegrationTestSuite**:
  - Add new test classes `UserPartyTest`, `UserCommitteeTest`, `UserCountryTest`, `UserMinistryTest`, `UserGovernmentBodyTest`, `UserParliamentTest`, `UserPoliticianTest`, and `UserDocumentTest` to the `@Suite.SuiteClasses` annotation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/cia/pull/7097?shareId=7d9ae401-c6bb-43f2-b7df-3dd9a6c42401).