### PR TITLE
Refactor page headers to use constants for improved maintainability and consistency

### DIFF
--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingAllMinistriesChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingAllMinistriesChartsPageModContentFactoryImpl.java
@@ -69,12 +69,17 @@ public final class MinistryRankingAllMinistriesChartsPageModContentFactoryImpl
 
 		final String pageId = getPageId(parameters);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Ministry Rankings", "All Ministries", "Visual representation of all ministries and their total headcount.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent, 
+            MinistryRankingViewConstants.TITLE_MINISTRY_RANKINGS,
+            MinistryRankingViewConstants.ALL_MINISTRIES_TITLE,
+            MinistryRankingViewConstants.ALL_MINISTRIES_DESC);
 
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
-		chartDataManager.createChartPanel(chartLayout, dataSeriesFactory.createMinistryChartTimeSeriesAll(), "All");
+		chartDataManager.createChartPanel(chartLayout, 
+            dataSeriesFactory.createMinistryChartTimeSeriesAll(), 
+            MinistryRankingViewConstants.CHART_LABEL_ALL_MINISTRIES);
 
 		panelContent.addComponent(chartLayout);
 		panelContent.setExpandRatio(chartLayout,ContentRatio.LARGE_FORM);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingAllPartiesChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingAllPartiesChartsPageModContentFactoryImpl.java
@@ -69,14 +69,17 @@ public final class MinistryRankingAllPartiesChartsPageModContentFactoryImpl
 
 		final String pageId = getPageId(parameters);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Ministry Rankings", "All Parties", "Visual representation of all parties and their total days served.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent, 
+            MinistryRankingViewConstants.TITLE_MINISTRY_RANKINGS,
+            MinistryRankingViewConstants.ALL_PARTIES_TITLE,
+            MinistryRankingViewConstants.ALL_PARTIES_DESC);
 
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
 		chartDataManager.createChartPanel(chartLayout,
 				dataSeriesFactory.createChartTimeSeriesTotalDaysServedGovernmentByParty(),
-				"All Parties, total days served");
+				MinistryRankingViewConstants.CHART_LABEL_ALL_PARTIES);
 
 		panelContent.addComponent(chartLayout);
 		panelContent.setExpandRatio(chartLayout,ContentRatio.LARGE_FORM);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingAllRolesChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingAllRolesChartsPageModContentFactoryImpl.java
@@ -43,50 +43,50 @@ import com.vaadin.ui.VerticalLayout;
  */
 @Service
 public final class MinistryRankingAllRolesChartsPageModContentFactoryImpl
-		extends AbstractMinistryRankingPageModContentFactoryImpl {
+        extends AbstractMinistryRankingPageModContentFactoryImpl {
 
-	/** The ministry ghant chart manager. */
-	@Autowired
-	private MinistryGhantChartManager ministryGhantChartManager;
+    /** The ministry ghant chart manager. */
+    @Autowired
+    private MinistryGhantChartManager ministryGhantChartManager;
 
-	/**
-	 * Instantiates a new ministry ranking all roles charts page mod content
-	 * factory impl.
-	 */
-	public MinistryRankingAllRolesChartsPageModContentFactoryImpl() {
-		super();
-	}
+    /**
+     * Instantiates a new ministry ranking all roles charts page mod content
+     * factory impl.
+     */
+    public MinistryRankingAllRolesChartsPageModContentFactoryImpl() {
+        super();
+    }
 
-	@Secured({ "ROLE_ANONYMOUS", "ROLE_USER", "ROLE_ADMIN" })
-	@Override
-	public Layout createContent(final String parameters, final MenuBar menuBar, final Panel panel) {
-		final VerticalLayout panelContent = createPanelContent();
+    @Secured({ "ROLE_ANONYMOUS", "ROLE_USER", "ROLE_ADMIN" })
+    @Override
+    public Layout createContent(final String parameters, final MenuBar menuBar, final Panel panel) {
+        final VerticalLayout panelContent = createPanelContent();
 
-		getMinistryRankingMenuItemFactory().createMinistryRankingMenuBar(menuBar);
+        getMinistryRankingMenuItemFactory().createMinistryRankingMenuBar(menuBar);
 
-		final String pageId = getPageId(parameters);
+        final String pageId = getPageId(parameters);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Ministry Rankings", "All Roles", "Visual representation of all government roles.");
+        CardInfoRowUtil.createPageHeader(panel, panelContent, 
+            MinistryRankingViewConstants.TITLE_MINISTRY_RANKINGS,
+            MinistryRankingViewConstants.ALL_ROLES_TITLE,
+            MinistryRankingViewConstants.ALL_ROLES_DESC);
 
-		final DataContainer<ViewRiksdagenGovermentRoleMember, String> govermentRoleMemberDataContainer = getApplicationManager()
-				.getDataContainer(ViewRiksdagenGovermentRoleMember.class);
+        final DataContainer<ViewRiksdagenGovermentRoleMember, String> govermentRoleMemberDataContainer = 
+            getApplicationManager().getDataContainer(ViewRiksdagenGovermentRoleMember.class);
 
-		final List<ViewRiksdagenGovermentRoleMember> allMembers = govermentRoleMemberDataContainer.getAll();
+        final List<ViewRiksdagenGovermentRoleMember> allMembers = govermentRoleMemberDataContainer.getAll();
 
-		ministryGhantChartManager.createRoleGhant(panelContent, allMembers);
+        ministryGhantChartManager.createRoleGhant(panelContent, allMembers);
 
+        getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_RANKING_VIEW, ApplicationEventGroup.USER,
+                NAME, parameters, pageId);
 
-		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_RANKING_VIEW, ApplicationEventGroup.USER,
-				NAME, parameters, pageId);
+        return panelContent;
+    }
 
-		return panelContent;
-
-	}
-
-	@Override
-	public boolean matches(final String page, final String parameters) {
-		return NAME.equals(page) && StringUtils.contains(parameters, PageMode.CHARTS.toString())
-				&& parameters.contains(ChartIndicators.ALL_GOVERNMENT_ROLE_CHART.toString());
-	}
-
+    @Override
+    public boolean matches(final String page, final String parameters) {
+        return NAME.equals(page) && StringUtils.contains(parameters, PageMode.CHARTS.toString())
+                && parameters.contains(ChartIndicators.ALL_GOVERNMENT_ROLE_CHART.toString());
+    }
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingCurrentMinistriesChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingCurrentMinistriesChartsPageModContentFactoryImpl.java
@@ -66,7 +66,10 @@ public final class MinistryRankingCurrentMinistriesChartsPageModContentFactoryIm
 
 		getMinistryRankingMenuItemFactory().createMinistryRankingMenuBar(menuBar);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Ministry Rankings", "Current Ministries", "Visual representation of current ministries and their total headcount.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent, 
+			MinistryRankingViewConstants.TITLE_MINISTRY_RANKINGS,
+			MinistryRankingViewConstants.CURRENT_MINISTRIES_TITLE,
+			MinistryRankingViewConstants.CURRENT_MINISTRIES_DESC);
 
 		final String pageId = getPageId(parameters);
 
@@ -74,8 +77,9 @@ public final class MinistryRankingCurrentMinistriesChartsPageModContentFactoryIm
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
-		chartDataManager.createChartPanel(chartLayout,dataSeriesFactory.createMinistryChartTimeSeriesCurrent(),
-				"Current Ministies, by headcount");
+		chartDataManager.createChartPanel(chartLayout,
+            dataSeriesFactory.createMinistryChartTimeSeriesCurrent(),
+            MinistryRankingViewConstants.CHART_LABEL_CURRENT_MINISTRIES);
 		panelContent.addComponent(chartLayout);
 		panelContent.setExpandRatio(chartLayout,ContentRatio.LARGE_FORM);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingCurrentPartiesChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingCurrentPartiesChartsPageModContentFactoryImpl.java
@@ -68,12 +68,16 @@ public final class MinistryRankingCurrentPartiesChartsPageModContentFactoryImpl 
 
 		final String pageId = getPageId(parameters);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Ministry Rankings", "Current Parties", "Visual representation of current parties and their headcount.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent, 
+            MinistryRankingViewConstants.TITLE_MINISTRY_RANKINGS,
+            MinistryRankingViewConstants.CURRENT_PARTIES_TITLE, 
+            MinistryRankingViewConstants.CURRENT_PARTIES_DESC);
 
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 
 		chartDataManager.createChartPanel(chartLayout,
-				dataSeriesFactory.createChartTimeSeriesCurrentGovernmentByParty(), "Current Parties, headcount");
+				dataSeriesFactory.createChartTimeSeriesCurrentGovernmentByParty(),
+				MinistryRankingViewConstants.CHART_LABEL_CURRENT_PARTIES);
 
 		chartLayout.setSizeFull();
 		panelContent.addComponent(chartLayout);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModContentFactoryImpl.java
@@ -91,8 +91,10 @@ public final class MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModCon
 
 		final String pageId = getPageId(parameters);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Ministry Rankings", "Leader Scoreboard",
-				"Visual representation of ministry leaders and their performance.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent, 
+            MinistryRankingViewConstants.TITLE_MINISTRY_RANKINGS,
+            MinistryRankingViewConstants.LEADER_SCOREBOARD_TITLE,
+            MinistryRankingViewConstants.LEADER_SCOREBOARD_DESC);
 
 		final ResponsiveRow row = RowUtil.createGridLayout(panelContent);
 		row.setSizeFull();
@@ -172,7 +174,6 @@ public final class MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModCon
 	@Override
 	public boolean matches(final String page, final String parameters) {
 		return NAME.equals(page) && StringUtils.contains(parameters, PageMode.CHARTS.toString())
-				&& parameters.contains(ChartIndicators.CURRENTMINISTRIESLEADERSCORECARD.toString());
-	}
+				&& parameters.contains(ChartIndicators.CURRENTMINISTRIESLEADERSCORECARD.toString());	}
 
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingGovernmentBodiesPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingGovernmentBodiesPageModContentFactoryImpl.java
@@ -60,8 +60,10 @@ public final class MinistryRankingGovernmentBodiesPageModContentFactoryImpl exte
 
 		final String pageId = getPageId(parameters);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Government Bodies", "Government Body Headcount", "Provides detailed headcount data for government bodies under ministries.");
-
+		CardInfoRowUtil.createPageHeader(panel, panelContent, 
+			MinistryRankingViewConstants.GOV_BODIES_TITLE,
+			MinistryRankingViewConstants.GOV_BODIES_HEADCOUNT_TITLE,
+			MinistryRankingViewConstants.GOV_BODIES_HEADCOUNT_DESC);
 
 		governmentBodyChartDataManager.createMinistryGovernmentBodyHeadcountSummaryChart(panelContent);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingGovernmentBodyExpenditurePageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingGovernmentBodyExpenditurePageModContentFactoryImpl.java
@@ -60,7 +60,10 @@ public final class MinistryRankingGovernmentBodyExpenditurePageModContentFactory
 
 		final String pageId = getPageId(parameters);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Government Bodies Expenditure", "Government Body Expenditure", "Provides detailed expenditure data for government bodies under ministries.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent, 
+			MinistryRankingViewConstants.GOV_BODY_EXP_TITLE,
+			MinistryRankingViewConstants.GOV_BODY_EXP_SUBTITLE,
+			MinistryRankingViewConstants.GOV_BODY_EXP_DESC);
 
 
 		governmentBodyChartDataManager.createMinistryGovernmentBodyExpenditureSummaryChart(panelContent);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingGovernmentBodyIncomePageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingGovernmentBodyIncomePageModContentFactoryImpl.java
@@ -60,7 +60,10 @@ public final class MinistryRankingGovernmentBodyIncomePageModContentFactoryImpl 
 
 		final String pageId = getPageId(parameters);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Government Bodies Income", "Government Body Income", "Provides detailed income data for government bodies under ministries.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent, 
+            MinistryRankingViewConstants.GOV_BODY_INCOME_TITLE,
+            MinistryRankingViewConstants.GOV_BODY_INCOME_SUBTITLE, 
+            MinistryRankingViewConstants.GOV_BODY_INCOME_DESC);
 
 
 		governmentBodyChartDataManager.createMinistryGovernmentBodyIncomeSummaryChart(panelContent);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingGovernmentOutcomePageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingGovernmentOutcomePageModContentFactoryImpl.java
@@ -58,17 +58,16 @@ public final class MinistryRankingGovernmentOutcomePageModContentFactoryImpl ext
 
 		getMinistryRankingMenuItemFactory().createMinistryRankingMenuBar(menuBar);
 		CardInfoRowUtil.createPageHeader(panel, panelContent,
-			    "Ministry Ranking - Government Outcomes",
-			    "Evaluating Results",
-			    "Evaluating ministry influence on governance results.");
+			    MinistryRankingViewConstants.GOV_OUTCOMES_TITLE,
+			    MinistryRankingViewConstants.GOV_OUTCOMES_SUBTITLE,
+			    MinistryRankingViewConstants.GOV_OUTCOMES_DESC);
 
 
 		final String pageId = getPageId(parameters);
 
 		governmentOutcomeChartDataManager.createGovernmentOutcomeChart(panelContent);
-
 		getPageActionEventHelper().createPageEvent(ViewAction.VISIT_MINISTRY_RANKING_VIEW, ApplicationEventGroup.USER, NAME,
-				parameters, pageId);
+                parameters, pageId);
 
 		return panelContent;
 
@@ -78,5 +77,4 @@ public final class MinistryRankingGovernmentOutcomePageModContentFactoryImpl ext
 	public boolean matches(final String page, final String parameters) {
 		return NAME.equals(page) && StringUtils.contains(parameters, MinistryPageMode.GOVERNMENT_OUTCOME.toString());
 	}
-
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingOverviewPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingOverviewPageModContentFactoryImpl.java
@@ -52,7 +52,10 @@ public final class MinistryRankingOverviewPageModContentFactoryImpl extends Abst
 		final VerticalLayout panelContent = createPanelContent();
 
 		getMinistryRankingMenuItemFactory().createMinistryRankingMenuBar(menuBar);
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Ministry Rankings", "Ranking Overview", "Evaluate and compare the performance of various ministries.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent, 
+            MinistryRankingViewConstants.TITLE_MINISTRY_RANKINGS,
+            MinistryRankingViewConstants.OVERVIEW_TITLE, 
+            MinistryRankingViewConstants.OVERVIEW_DESC);
 
 
 		final String pageId = getPageId(parameters);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingPageVisitHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingPageVisitHistoryPageModContentFactoryImpl.java
@@ -55,7 +55,10 @@ public final class MinistryRankingPageVisitHistoryPageModContentFactoryImpl
 
 		final String pageId = getPageId(parameters);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Ministry Rankings", "Page Visit History", "Tracks and visualizes the history of page visits for ministry rankings.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent, 
+            MinistryRankingViewConstants.TITLE_MINISTRY_RANKINGS,
+            MinistryRankingViewConstants.PAGE_HISTORY_TITLE,
+            MinistryRankingViewConstants.PAGE_HISTORY_DESC);
 
 		getAdminChartDataManager().createApplicationActionEventPageModeDailySummaryChart(panelContent,NAME);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingViewConstants.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/MinistryRankingViewConstants.java
@@ -1,0 +1,69 @@
+package com.hack23.cia.web.impl.ui.application.views.user.govermentranking.pagemode;
+
+/**
+ * Constants for the government body view pages.
+ */
+public interface MinistryRankingViewConstants {
+
+    // Common View Title
+    String TITLE_MINISTRY_RANKINGS = "Ministry Rankings";
+
+    // Overview Page
+    String OVERVIEW_TITLE = "Ranking Overview";  
+    String OVERVIEW_DESC = "Evaluate and compare the performance of various ministries.";
+
+    // Current Ministries Page
+    String CURRENT_MINISTRIES_TITLE = "Current Ministries";
+    String CURRENT_MINISTRIES_DESC = "Visual representation of current ministries and their total headcount.";
+
+    // All Ministries Page
+    String ALL_MINISTRIES_TITLE = "All Ministries";
+    String ALL_MINISTRIES_DESC = "Visual representation of all ministries and their total headcount.";
+
+    // Page Visit History
+    String PAGE_HISTORY_TITLE = "Page Visit History";
+    String PAGE_HISTORY_DESC = "Tracks and visualizes the history of page visits for ministry rankings.";
+
+    // Leader Scoreboard
+    String LEADER_SCOREBOARD_TITLE = "Leader Scoreboard";
+    String LEADER_SCOREBOARD_DESC = "Visual representation of ministry leaders and their performance.";
+
+    // Government Bodies Pages
+    String GOV_BODIES_TITLE = "Government Bodies";
+    String GOV_BODIES_HEADCOUNT_TITLE = "Government Body Headcount";
+    String GOV_BODIES_HEADCOUNT_DESC = "Provides detailed headcount data for government bodies under ministries.";
+
+    // Government Body Income
+    String GOV_BODY_INCOME_TITLE = "Government Bodies Income";
+    String GOV_BODY_INCOME_SUBTITLE = "Government Body Income";
+    String GOV_BODY_INCOME_DESC = "Provides detailed income data for government bodies under ministries.";
+
+    // Government Body Expenditure
+    String GOV_BODY_EXP_TITLE = "Government Bodies Expenditure";
+    String GOV_BODY_EXP_SUBTITLE = "Government Body Expenditure";
+    String GOV_BODY_EXP_DESC = "Provides detailed expenditure data for government bodies under ministries.";
+
+    // Government Outcomes
+    String GOV_OUTCOMES_TITLE = "Ministry Ranking - Government Outcomes";
+    String GOV_OUTCOMES_SUBTITLE = "Evaluating Results";
+    String GOV_OUTCOMES_DESC = "Evaluating ministry influence on governance results.";
+
+    // Current Parties Page
+    String CURRENT_PARTIES_TITLE = "Current Parties";
+    String CURRENT_PARTIES_DESC = "Visual representation of current parties and their headcount.";
+
+    // All Parties Page
+    String ALL_PARTIES_TITLE = "All Parties";
+    String ALL_PARTIES_DESC = "Visual representation of all parties and their total days served.";
+
+    // All Roles Page
+    String ALL_ROLES_TITLE = "All Roles";
+    String ALL_ROLES_DESC = "Visual representation of all government roles.";
+
+    // Chart Labels
+    String CHART_LABEL_CURRENT_PARTIES = "Current Parties, headcount";
+    String CHART_LABEL_CURRENT_MINISTRIES = "Current Ministries, by headcount";
+    String CHART_LABEL_ALL_MINISTRIES = "All";
+    String CHART_LABEL_ALL_PARTIES = "All Parties, total days served";
+}
+

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/ministry/UserMinistryTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/ministry/UserMinistryTest.java
@@ -8,6 +8,7 @@ import com.hack23.cia.systemintegrationtest.categories.IntegrationTest;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandMinistryConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandMinistryRankingConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandUserConstants;
+import com.hack23.cia.web.impl.ui.application.views.user.govermentranking.pagemode.MinistryRankingViewConstants;
 
 /**
  * The Class UserMinistryTest.
@@ -23,9 +24,10 @@ public final class UserMinistryTest extends AbstractUITest implements PageComman
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyMinistryPage() throws Exception {
         pageVisit.visitDirectPage(PageCommandMinistryConstants.MINISTRY_COMMAND_CHARTS_CURRENT_BY_HEADCOUNT);
-        pageVisit.verifyViewContent("Ministry Rankings",
-            "Current Ministries",
-            "Visual representation of current ministries and their total headcount.");
+        pageVisit.verifyViewContent(
+            MinistryRankingViewConstants.TITLE_MINISTRY_RANKINGS,
+            MinistryRankingViewConstants.CURRENT_MINISTRIES_TITLE,
+            MinistryRankingViewConstants.CURRENT_MINISTRIES_DESC);
         pageVisit.validatePage(PageCommandMinistryConstants.MINISTRY_COMMAND_CHARTS_CURRENT_BY_HEADCOUNT);
     }
 
@@ -37,9 +39,10 @@ public final class UserMinistryTest extends AbstractUITest implements PageComman
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyMinistryRankingPage() throws Exception {
         pageVisit.visitDirectPage(PageCommandMinistryRankingConstants.COMMAND_MINISTRY_RANKING_DATAGRID);
-        pageVisit.verifyViewContent("Ministry Rankings",
-            "All Ministries",
-            "Visual representation of all ministries and their total headcount.");
+        pageVisit.verifyViewContent(
+            MinistryRankingViewConstants.TITLE_MINISTRY_RANKINGS,
+            MinistryRankingViewConstants.ALL_MINISTRIES_TITLE,
+            MinistryRankingViewConstants.ALL_MINISTRIES_DESC);
         pageVisit.validatePage(PageCommandMinistryRankingConstants.COMMAND_MINISTRY_RANKING_DATAGRID);
     }
 
@@ -51,9 +54,10 @@ public final class UserMinistryTest extends AbstractUITest implements PageComman
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyMinistryRankingOverviewPage() throws Exception {
         pageVisit.visitDirectPage(PageCommandMinistryRankingConstants.COMMAND_MINISTRY_RANKING_OVERVIEW);
-        pageVisit.verifyViewContent("Ministry Rankings",
-            "Page Visit History",
-            "Tracks and visualizes the history of page visits for ministry rankings.");
+        pageVisit.verifyViewContent(
+            MinistryRankingViewConstants.TITLE_MINISTRY_RANKINGS,
+            MinistryRankingViewConstants.PAGE_HISTORY_TITLE,
+            MinistryRankingViewConstants.PAGE_HISTORY_DESC);
         pageVisit.validatePage(PageCommandMinistryRankingConstants.COMMAND_MINISTRY_RANKING_OVERVIEW);
     }
 
@@ -65,9 +69,10 @@ public final class UserMinistryTest extends AbstractUITest implements PageComman
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyChartsCurrentMinistriesLeaderScoreboardPage() throws Exception {
         pageVisit.visitDirectPage(PageCommandMinistryRankingConstants.COMMAND_CHARTS_CURRENT_MINISTRIES_LEADER_SCOREBOARD);
-        pageVisit.verifyViewContent("Ministry Rankings",
-            "Leader Scoreboard",
-            "Visual representation of ministry leaders and their performance.");
+        pageVisit.verifyViewContent(
+            MinistryRankingViewConstants.TITLE_MINISTRY_RANKINGS,
+            MinistryRankingViewConstants.LEADER_SCOREBOARD_TITLE,
+            MinistryRankingViewConstants.LEADER_SCOREBOARD_DESC);
         pageVisit.validatePage(PageCommandMinistryRankingConstants.COMMAND_CHARTS_CURRENT_MINISTRIES_LEADER_SCOREBOARD);
     }
 
@@ -79,9 +84,10 @@ public final class UserMinistryTest extends AbstractUITest implements PageComman
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyChartsCurrentMinistriesByHeadcountPage() throws Exception {
         pageVisit.visitDirectPage(PageCommandMinistryRankingConstants.COMMAND_CHARTS_CURRENT_MINISTRIES_BY_HEADCOUNT);
-        pageVisit.verifyViewContent("Ministry Rankings",
-            "Current Parties",
-            "Visual representation of current parties and their headcount.");
+        pageVisit.verifyViewContent(
+            MinistryRankingViewConstants.TITLE_MINISTRY_RANKINGS,
+            MinistryRankingViewConstants.CURRENT_PARTIES_TITLE,
+            MinistryRankingViewConstants.CURRENT_PARTIES_DESC);
         pageVisit.validatePage(PageCommandMinistryRankingConstants.COMMAND_CHARTS_CURRENT_MINISTRIES_BY_HEADCOUNT);
     }
 
@@ -93,9 +99,10 @@ public final class UserMinistryTest extends AbstractUITest implements PageComman
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyAllMinistriesByHeadcountPage() throws Exception {
         pageVisit.visitDirectPage(PageCommandMinistryRankingConstants.COMMAND_CHARTS_ALL_MINISTRIES_BY_HEADCOUNT);
-        pageVisit.verifyViewContent("Ministry Rankings",
-            "All Roles",
-            "Visual representation of all government roles.");
+        pageVisit.verifyViewContent(
+            MinistryRankingViewConstants.TITLE_MINISTRY_RANKINGS,
+            MinistryRankingViewConstants.ALL_ROLES_TITLE,
+            MinistryRankingViewConstants.ALL_ROLES_DESC);
         pageVisit.validatePage(PageCommandMinistryRankingConstants.COMMAND_CHARTS_ALL_MINISTRIES_BY_HEADCOUNT);
     }
 }


### PR DESCRIPTION
Refactor page headers to utilize constants from `MinistryRankingViewConstants`, enhancing code maintainability and ensuring consistent usage across the application.