### PR TITLE
Refactor party ranking view headers to use constants

### DIFF
--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandParliamentRankingConstants.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandParliamentRankingConstants.java
@@ -58,4 +58,5 @@ public interface PageCommandParliamentRankingConstants {
         PageModeMenuCommand COMMAND_CHARTS_DECISION_ACTIVITY = new PageModeMenuCommand(
             UserViews.PARLIAMENT_RANKING_VIEW_NAME, PageMode.CHARTS, ChartIndicators.DECISIONACTIVITYBYTYPE.toString());
 
+
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandPartyRankingConstants.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandPartyRankingConstants.java
@@ -16,22 +16,6 @@ public interface PageCommandPartyRankingConstants {
                      UserViews.PARTY_RANKING_VIEW_NAME, PageMode.CHARTS,
                      ChartIndicators.CURRENTGOVERMENTPARTIES.toString());
 
-    /** The command charts party age. */
-    PageModeMenuCommand COMMAND_CHARTS_PARTY_AGE = new PageModeMenuCommand(
-                     UserViews.PARLIAMENT_RANKING_VIEW_NAME,
-                     PageMode.CHARTS, ChartIndicators.PARTYAGE.toString());
-
-    /** The command charts party gender. */
-    PageModeMenuCommand COMMAND_CHARTS_PARTY_GENDER = new PageModeMenuCommand(
-                     UserViews.PARLIAMENT_RANKING_VIEW_NAME,
-                     PageMode.CHARTS, ChartIndicators.PARTYGENDER.toString());
-
-    /** The command charts party winner. */
-    PageModeMenuCommand COMMAND_CHARTS_PARTY_WINNER = new PageModeMenuCommand(
-                     UserViews.PARLIAMENT_RANKING_VIEW_NAME,
-                     PageMode.CHARTS, ChartIndicators.PARTYWINNER.toString());
-
-
     /** The command party leader scoreboard. */
     PageModeMenuCommand COMMAND_PARTY_LEADER_SCOREBOARD = new PageModeMenuCommand(
         UserViews.PARTY_RANKING_VIEW_NAME, PageMode.CHARTS, ChartIndicators.CURRENTPARTYLEADERSCORECARD.toString());

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingAllPartiesChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingAllPartiesChartsPageModContentFactoryImpl.java
@@ -70,12 +70,17 @@ public final class PartyRankingAllPartiesChartsPageModContentFactoryImpl extends
 
 		getPartyRankingMenuItemFactory().createPartyRankingMenuBar(menuBar);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "All Parties Charts", "Party Performance", "Analyze the performance of all political parties using various charts.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent,
+			PartyRankingViewConstants.ALL_PARTIES_TITLE,
+			PartyRankingViewConstants.TITLE_PARTY_RANKINGS,
+			PartyRankingViewConstants.ALL_PARTIES_DESC);
 
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
-		chartDataManager.createChartPanel(chartLayout,dataSeriesFactory.createPartyChartTimeSeriesAll(),"Number of party members having roles in Parliament or Government Since 1983");
+		chartDataManager.createChartPanel(chartLayout,
+			dataSeriesFactory.createPartyChartTimeSeriesAll(),
+			PartyRankingViewConstants.CHART_LABEL_ALL_PARTIES);
 
 		panelContent.addComponent(chartLayout);
 		panelContent.setExpandRatio(chartLayout,ContentRatio.LARGE_FORM);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingCurrentCommitteeChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingCurrentCommitteeChartsPageModContentFactoryImpl.java
@@ -70,12 +70,17 @@ public final class PartyRankingCurrentCommitteeChartsPageModContentFactoryImpl e
 
 		getPartyRankingMenuItemFactory().createPartyRankingMenuBar(menuBar);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Current Committee Charts", "Committee Performance", "Analyze the performance of current committees using various charts.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent,
+			PartyRankingViewConstants.CURRENT_COMMITTEE_TITLE,
+			PartyRankingViewConstants.TITLE_PARTY_RANKINGS,
+			PartyRankingViewConstants.CURRENT_COMMITTEE_DESC);
 
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
-		chartDataManager.createChartPanel(chartLayout,dataSeriesFactory.createChartTimeSeriesCurrentCommitteeByParty(),"Party Total Active in Committee");
+		chartDataManager.createChartPanel(chartLayout,
+			dataSeriesFactory.createChartTimeSeriesCurrentCommitteeByParty(),
+			PartyRankingViewConstants.CHART_LABEL_CURRENT_COMMITTEE);
 
 		panelContent.addComponent(chartLayout);
 		panelContent.setExpandRatio(chartLayout,ContentRatio.LARGE_FORM);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingCurrentGovernmentChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingCurrentGovernmentChartsPageModContentFactoryImpl.java
@@ -71,12 +71,17 @@ public final class PartyRankingCurrentGovernmentChartsPageModContentFactoryImpl 
 
 		getPartyRankingMenuItemFactory().createPartyRankingMenuBar(menuBar);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Current Government Charts", "Government Performance", "Analyze the performance of the current government using various charts.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent, 
+            PartyRankingViewConstants.CURRENT_GOVERNMENT_TITLE,
+            PartyRankingViewConstants.TITLE_PARTY_RANKINGS,
+            PartyRankingViewConstants.CURRENT_GOVERNMENT_DESC);
 
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
-		chartDataManager.createChartPanel(chartLayout,dataSeriesFactory.createChartTimeSeriesCurrentGovernmentByParty(),"Party Total Active in Government");
+		chartDataManager.createChartPanel(chartLayout,
+            dataSeriesFactory.createChartTimeSeriesCurrentGovernmentByParty(),
+            PartyRankingViewConstants.CHART_LABEL_CURRENT_GOVERNMENT);
 
 		panelContent.addComponent(chartLayout);
 		panelContent.setExpandRatio(chartLayout,ContentRatio.LARGE_FORM);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingCurrentPartiesChartsPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingCurrentPartiesChartsPageModContentFactoryImpl.java
@@ -68,17 +68,19 @@ public final class PartyRankingCurrentPartiesChartsPageModContentFactoryImpl ext
 
 		final String pageId = getPageId(parameters);
 
-
 		getPartyRankingMenuItemFactory().createPartyRankingMenuBar(menuBar);
+		
 		CardInfoRowUtil.createPageHeader(panel, panelContent,
-			    "Party Ranking - Current Parties Charts",
-			    "Current Party Dynamics",
-			    "Current parties: gauging influence and strategic footholds.");
+		    PartyRankingViewConstants.CURRENT_PARTIES_TITLE,
+		    PartyRankingViewConstants.TITLE_PARTY_RANKINGS,
+		    PartyRankingViewConstants.CURRENT_PARTIES_DESC);
 
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();
 
-		chartDataManager.createChartPanel(chartLayout,dataSeriesFactory.createPartyChartTimeSeriesCurrent(),"Party Total Active in Parliament");
+		chartDataManager.createChartPanel(chartLayout,
+		    dataSeriesFactory.createPartyChartTimeSeriesCurrent(),
+		    PartyRankingViewConstants.CHART_LABEL_CURRENT_PARTIES);
 
 		panelContent.addComponent(chartLayout);
 		panelContent.setExpandRatio(chartLayout,ContentRatio.LARGE_FORM);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingCurrentPartiesLeaderScoreboardPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingCurrentPartiesLeaderScoreboardPageModContentFactoryImpl.java
@@ -91,8 +91,10 @@ public final class PartyRankingCurrentPartiesLeaderScoreboardPageModContentFacto
 		final String pageId = getPageId(parameters);
 		getPartyRankingMenuItemFactory().createPartyRankingMenuBar(menuBar);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Current Party Leaders Scoreboard", "Leader Performance",
-				"Evaluate the performance of current party leaders including those not in government.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent,
+			PartyRankingViewConstants.LEADER_SCOREBOARD_TITLE,
+			PartyRankingViewConstants.TITLE_PARTY_RANKINGS,
+			PartyRankingViewConstants.LEADER_SCOREBOARD_DESC);
 
 		final HorizontalLayout chartLayout = new HorizontalLayout();
 		chartLayout.setSizeFull();

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingDataGridPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingDataGridPageModContentFactoryImpl.java
@@ -129,8 +129,12 @@ public final class PartyRankingDataGridPageModContentFactoryImpl extends Abstrac
 		final VerticalLayout panelContent = createPanelContent();
 
 		getPartyRankingMenuItemFactory().createPartyRankingMenuBar(menuBar);
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Party Performance Dashboard", "Party Rankings", "Evaluate political parties using data on legislative activity, assignments, and influence.");
-
+		
+		CardInfoRowUtil.createPageHeader(panel, panelContent,
+		    PartyRankingViewConstants.DATAGRID_TITLE,
+		    PartyRankingViewConstants.TITLE_PARTY_RANKINGS,
+		    PartyRankingViewConstants.DATAGRID_DESC);
+		    
 		final String pageId = getPageId(parameters);
 
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingOverviewPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingOverviewPageModContentFactoryImpl.java
@@ -54,7 +54,11 @@ public final class PartyRankingOverviewPageModContentFactoryImpl extends Abstrac
 		final VerticalLayout panelContent = createPanelContent();
 
 		getPartyRankingMenuItemFactory().createPartyRankingMenuBar(menuBar);
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Party Rankings", "Ranking Overview", "Compare and rank political parties based on predefined metrics.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent,
+			PartyRankingViewConstants.OVERVIEW_TITLE,
+			PartyRankingViewConstants.TITLE_PARTY_RANKINGS,
+			PartyRankingViewConstants.OVERVIEW_DESC);
+            
 		final String pageId = getPageId(parameters);
 
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingPageVisitHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingPageVisitHistoryPageModContentFactoryImpl.java
@@ -58,7 +58,10 @@ public final class PartyRankingPageVisitHistoryPageModContentFactoryImpl
 
 		final String pageId = getPageId(parameters);
 
-		CardInfoRowUtil.createPageHeader(panel, panelContent, "Page Visit History", "User Activity", "Track the history of page visits for party rankings.");
+		CardInfoRowUtil.createPageHeader(panel, panelContent, 
+            PartyRankingViewConstants.PAGE_HISTORY_TITLE,
+            PartyRankingViewConstants.TITLE_PARTY_RANKINGS,
+            PartyRankingViewConstants.PAGE_HISTORY_DESC);
 
 		getAdminChartDataManager().createApplicationActionEventPageModeDailySummaryChart(panelContent,NAME);
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingViewConstants.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/PartyRankingViewConstants.java
@@ -1,9 +1,47 @@
 package com.hack23.cia.web.impl.ui.application.views.user.partyranking.pagemode;
 
 /**
- * The Interface PartyRankingViewConstants.
+ * Constants for the party ranking view pages.
  */
 public interface PartyRankingViewConstants {
 
+    // Common View Title
+    String TITLE_PARTY_RANKINGS = "Party Rankings";
+
+    // Overview Page
+    String OVERVIEW_TITLE = "Ranking Overview";
+    String OVERVIEW_DESC = "Compare and rank political parties based on predefined metrics.";
+
+    // Current Parties Page
+    String CURRENT_PARTIES_TITLE = "Current Parties Charts";
+    String CURRENT_PARTIES_DESC = "Visual representation of current parties and their parliamentary presence.";
+    String CHART_LABEL_CURRENT_PARTIES = "Party Total Active in Parliament";
+
+    // All Parties Page
+    String ALL_PARTIES_TITLE = "All Parties Charts";
+    String ALL_PARTIES_DESC = "Analyze the performance of all political parties using various charts.";
+    String CHART_LABEL_ALL_PARTIES = "Number of party members having roles in Parliament or Government Since 1983";
+
+    // Current Committee Page
+    String CURRENT_COMMITTEE_TITLE = "Current Committee Charts";
+    String CURRENT_COMMITTEE_DESC = "Analyze the performance of current committees using various charts.";
+    String CHART_LABEL_CURRENT_COMMITTEE = "Party Total Active in Committee";
+
+    // Current Government Page
+    String CURRENT_GOVERNMENT_TITLE = "Current Government Charts";
+    String CURRENT_GOVERNMENT_DESC = "Analyze the performance of the current government using various charts.";
+    String CHART_LABEL_CURRENT_GOVERNMENT = "Party Total Active in Government";
+
+    // Leader Scoreboard Page
+    String LEADER_SCOREBOARD_TITLE = "Current Party Leaders Scoreboard";
+    String LEADER_SCOREBOARD_DESC = "Evaluate the performance of current party leaders including those not in government.";
+
+    // Data Grid Page
+    String DATAGRID_TITLE = "Party Performance Dashboard";
+    String DATAGRID_DESC = "Evaluate political parties using data on legislative activity, assignments, and influence.";
+
+    // Page Visit History
+    String PAGE_HISTORY_TITLE = "Page Visit History";
+    String PAGE_HISTORY_DESC = "Track the history of page visits for party rankings.";
 }
 

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/parliament/UserParliamentTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/parliament/UserParliamentTest.java
@@ -7,6 +7,7 @@ import com.hack23.cia.systemintegrationtest.AbstractUITest;
 import com.hack23.cia.systemintegrationtest.categories.IntegrationTest;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandParliamentRankingConstants;
 import com.hack23.cia.web.impl.ui.application.views.user.parliament.pagemode.ParliamentPageTitleConstants;
+import com.hack23.cia.web.impl.ui.application.views.user.parliament.pagemode.ParliamentViewConstants;
 
 /**
  * The Class UserParliamentTest.
@@ -107,8 +108,54 @@ public final class UserParliamentTest extends AbstractUITest {
     public void verifyDecisionFlowPage() throws Exception {
         pageVisit.visitDirectPage(PageCommandParliamentRankingConstants.COMMAND_CHARTS_DECISION_FLOW);
         pageVisit.verifyViewContent(ParliamentPageTitleConstants.DECISION_FLOW_TITLE,
-            ParliamentPageTitleConstants.DECISION_FLOW_SUBTITLE,
-            ParliamentPageTitleConstants.DECISION_FLOW_DESC);
+        ParliamentPageTitleConstants.DECISION_FLOW_SUBTITLE,
+        ParliamentPageTitleConstants.DECISION_FLOW_DESC);
         pageVisit.validatePage(PageCommandParliamentRankingConstants.COMMAND_CHARTS_DECISION_FLOW);
     }
+
+        /**
+     * Verify party winner page.
+     *
+     * @throws Exception the exception
+     */
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyPartyWinnerPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandParliamentRankingConstants.COMMAND_CHARTS_PARTY_WINNER);
+        pageVisit.verifyViewContent(
+            ParliamentViewConstants.PARTY_WINNER_TITLE,
+		    ParliamentViewConstants.PARTY_WINNER_SUBTITLE,
+		    ParliamentViewConstants.PARTY_WINNER_DESC);
+        pageVisit.validatePage(PageCommandParliamentRankingConstants.COMMAND_CHARTS_PARTY_WINNER);
+    }
+
+    /**
+     * Verify party gender page.
+     *
+     * @throws Exception the exception
+     */
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyPartyGenderPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandParliamentRankingConstants.COMMAND_CHARTS_PARTY_GENDER);
+        pageVisit.verifyViewContent(
+            ParliamentPageTitleConstants.PARTY_GENDER_TITLE,
+		    ParliamentPageTitleConstants.PARTY_GENDER_SUBTITLE,
+		    ParliamentPageTitleConstants.PARTY_GENDER_DESC);
+        pageVisit.validatePage(PageCommandParliamentRankingConstants.COMMAND_CHARTS_PARTY_GENDER);
+    }
+
+    /**
+     * Verify party age page.
+     *
+     * @throws Exception the exception
+     */
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyPartyAgePage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandParliamentRankingConstants.COMMAND_CHARTS_PARTY_AGE);
+        pageVisit.verifyViewContent(
+            ParliamentPageTitleConstants.PARTY_AGE_TITLE,
+            ParliamentPageTitleConstants.PARTY_AGE_SUBTITLE,
+            ParliamentPageTitleConstants.PARTY_AGE_DESC);
+        pageVisit.validatePage(PageCommandParliamentRankingConstants.COMMAND_CHARTS_PARTY_AGE);
+    }
+
 }

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/party/UserPartyTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/party/UserPartyTest.java
@@ -6,6 +6,7 @@ import org.junit.experimental.categories.Category;
 import com.hack23.cia.systemintegrationtest.AbstractUITest;
 import com.hack23.cia.systemintegrationtest.categories.IntegrationTest;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandPartyRankingConstants;
+import com.hack23.cia.web.impl.ui.application.views.user.partyranking.pagemode.PartyRankingViewConstants;
 
 /**
  * The Class UserPartyTest.
@@ -21,9 +22,10 @@ public final class UserPartyTest extends AbstractUITest {
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyPartyPage() throws Exception {
         pageVisit.visitDirectPage(PageCommandPartyRankingConstants.COMMAND_CHARTS_CURRENT_GOVERNMENT_PARTIES);
-        pageVisit.verifyViewContent("Current Government Charts",
-            "Government Performance",
-            "Analyze the performance of the current government using various charts.");
+        pageVisit.verifyViewContent(
+            PartyRankingViewConstants.CURRENT_GOVERNMENT_TITLE,
+            PartyRankingViewConstants.TITLE_PARTY_RANKINGS,
+            PartyRankingViewConstants.CURRENT_GOVERNMENT_DESC);
         pageVisit.validatePage(PageCommandPartyRankingConstants.COMMAND_CHARTS_CURRENT_GOVERNMENT_PARTIES);
     }
 
@@ -35,52 +37,11 @@ public final class UserPartyTest extends AbstractUITest {
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyPartyRankingPage() throws Exception {
         pageVisit.visitDirectPage(PageCommandPartyRankingConstants.COMMAND_PARTY_RANKING_OVERVIEW);
-        pageVisit.verifyViewContent("Party Rankings",
-            "Ranking Overview",
-            "Compare and rank political parties based on predefined metrics.");
+        pageVisit.verifyViewContent(
+            PartyRankingViewConstants.OVERVIEW_TITLE,
+            PartyRankingViewConstants.TITLE_PARTY_RANKINGS,
+            PartyRankingViewConstants.OVERVIEW_DESC);
         pageVisit.validatePage(PageCommandPartyRankingConstants.COMMAND_PARTY_RANKING_OVERVIEW);
-    }
-
-    /**
-     * Verify party winner page.
-     *
-     * @throws Exception the exception
-     */
-    @Test(timeout = DEFAULT_TIMEOUT)
-    public void verifyPartyWinnerPage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandPartyRankingConstants.COMMAND_CHARTS_PARTY_WINNER);
-        pageVisit.verifyViewContent("Party Performance Dashboard",
-            "Party Rankings",
-            "Evaluate political parties using data on legislative activity, assignments, and influence.");
-        pageVisit.validatePage(PageCommandPartyRankingConstants.COMMAND_CHARTS_PARTY_WINNER);
-    }
-
-    /**
-     * Verify party gender page.
-     *
-     * @throws Exception the exception
-     */
-    @Test(timeout = DEFAULT_TIMEOUT)
-    public void verifyPartyGenderPage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandPartyRankingConstants.COMMAND_CHARTS_PARTY_GENDER);
-        pageVisit.verifyViewContent("Party Ranking - Current Parties Charts",
-            "Current Party Dynamics",
-            "Current parties: gauging influence and strategic footholds.");
-        pageVisit.validatePage(PageCommandPartyRankingConstants.COMMAND_CHARTS_PARTY_GENDER);
-    }
-
-    /**
-     * Verify party age page.
-     *
-     * @throws Exception the exception
-     */
-    @Test(timeout = DEFAULT_TIMEOUT)
-    public void verifyPartyAgePage() throws Exception {
-        pageVisit.visitDirectPage(PageCommandPartyRankingConstants.COMMAND_CHARTS_PARTY_AGE);
-        pageVisit.verifyViewContent("Current Party Leaders Scoreboard",
-            "Leader Performance",
-            "Evaluate the performance of current party leaders including those not in government.");
-        pageVisit.validatePage(PageCommandPartyRankingConstants.COMMAND_CHARTS_PARTY_AGE);
     }
 
     /**
@@ -91,9 +52,10 @@ public final class UserPartyTest extends AbstractUITest {
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyPartiesLinkPage() throws Exception {
         pageVisit.visitDirectPage(PageCommandPartyRankingConstants.COMMAND_PARTY_RANKING_DATAGRID);
-        pageVisit.verifyViewContent("All Parties Charts",
-            "Party Performance",
-            "Analyze the performance of all political parties using various charts.");
+        pageVisit.verifyViewContent(
+            PartyRankingViewConstants.DATAGRID_TITLE,
+            PartyRankingViewConstants.TITLE_PARTY_RANKINGS,
+            PartyRankingViewConstants.DATAGRID_DESC);
         pageVisit.validatePage(PageCommandPartyRankingConstants.COMMAND_PARTY_RANKING_DATAGRID);
     }
 
@@ -105,9 +67,10 @@ public final class UserPartyTest extends AbstractUITest {
     @Test(timeout = DEFAULT_TIMEOUT)
     public void verifyPartyRankingPageVisitHistoryPage() throws Exception {
         pageVisit.visitDirectPage(PageCommandPartyRankingConstants.PARTY_RANKING_COMMAND_PAGEVISIT_HISTORY);
-        pageVisit.verifyViewContent("Page Visit History",
-            "User Activity",
-            "Track the history of page visits for party rankings.");
+        pageVisit.verifyViewContent(
+            PartyRankingViewConstants.PAGE_HISTORY_TITLE,
+            PartyRankingViewConstants.TITLE_PARTY_RANKINGS,
+            PartyRankingViewConstants.PAGE_HISTORY_DESC);
         pageVisit.validatePage(PageCommandPartyRankingConstants.PARTY_RANKING_COMMAND_PAGEVISIT_HISTORY);
     }
 }


### PR DESCRIPTION
Update page headers in party ranking views to utilize constants for improved maintainability and readability. This change enhances consistency across the application.