### PR TITLE
Add package-info.java files to ranking packages

### DIFF
--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committeeranking/package-info.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committeeranking/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * This package provides classes and interfaces for managing committee rankings within the Citizen Intelligence Agency web application.
+ *
+ * Key classes and interfaces:
+ * - CommitteeRankingView: View class for displaying committee rankings.
+ *
+ * Dependencies and relationships:
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.pagemode for PageModeContentFactory.
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.viewnames for UserViews and CommitteeRankingPageMode.
+ * - Depends on com.hack23.cia.model.internal.application.data.committee.impl for ViewRiksdagenCommittee and related entities.
+ * - Depends on com.hack23.cia.service.api for data container and application manager services.
+ * - Depends on org.springframework.security.access.annotation for security annotations.
+ * - Depends on org.springframework.stereotype for component annotations.
+ * - Depends on com.vaadin.ui for UI components.
+ */
+package com.hack23.cia.web.impl.ui.application.views.user.committeeranking;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committeeranking/pagemode/CommitteeRankingConstants.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committeeranking/pagemode/CommitteeRankingConstants.java
@@ -2,6 +2,41 @@ package com.hack23.cia.web.impl.ui.application.views.user.committeeranking.pagem
 
 /**
  * The Interface CommitteeRankingConstants.
+ *
+ * This interface defines constants used for committee ranking views and page modes
+ * within the Citizen Intelligence Agency web application.
+ *
+ * Key constants:
+ * - CR_OVERVIEW_TITLE_HEADER: Title header for the committee ranking overview.
+ * - CR_OVERVIEW_TITLE: Title for the committee ranking overview.
+ * - CR_OVERVIEW_DESCRIPTION: Description for the committee ranking overview.
+ * - CR_GRID_TITLE_HEADER: Title header for the committee ranking data grid.
+ * - CR_GRID_TITLE: Title for the committee ranking data grid.
+ * - CR_GRID_DESCRIPTION: Description for the committee ranking data grid.
+ * - CR_VISIT_TITLE_HEADER: Title header for the committee ranking visit history.
+ * - CR_VISIT_TITLE: Title for the committee ranking visit history.
+ * - CR_VISIT_DESCRIPTION: Description for the committee ranking visit history.
+ * - CR_ALL_TITLE_HEADER: Title header for the all committees charts.
+ * - CR_ALL_TITLE: Title for the all committees charts.
+ * - CR_ALL_DESCRIPTION: Description for the all committees charts.
+ * - CR_CURRENT_TITLE_HEADER: Title header for the current committees charts.
+ * - CR_CURRENT_TITLE: Title for the current committees charts.
+ * - CR_CURRENT_DESCRIPTION: Description for the current committees charts.
+ * - CR_PARTY_TITLE_HEADER: Title header for the committee by party charts.
+ * - CR_PARTY_TITLE: Title for the committee by party charts.
+ * - CR_PARTY_DESCRIPTION: Description for the committee by party charts.
+ * - CR_CURRENT_PARTY_TITLE_HEADER: Title header for the current committee parties charts.
+ * - CR_CURRENT_PARTY_TITLE: Title for the current committee parties charts.
+ * - CR_CURRENT_PARTY_DESCRIPTION: Description for the current committee parties charts.
+ *
+ * Dependencies and relationships:
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.pagemode for PageModeContentFactory.
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.viewnames for UserViews and CommitteeRankingPageMode.
+ * - Depends on com.hack23.cia.model.internal.application.data.committee.impl for ViewRiksdagenCommittee and related entities.
+ * - Depends on com.hack23.cia.service.api for data container and application manager services.
+ * - Depends on org.springframework.security.access.annotation for security annotations.
+ * - Depends on org.springframework.stereotype for component annotations.
+ * - Depends on com.vaadin.ui for UI components.
  */
 public interface CommitteeRankingConstants {
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committeeranking/pagemode/package-info.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/committeeranking/pagemode/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * This package provides classes and interfaces for managing page modes within committee ranking views.
+ *
+ * Key classes and interfaces:
+ * - AbstractCommitteeRankingPageModContentFactoryImpl: Abstract base class for committee ranking page mode content factories.
+ * - CommitteeRankingAllCommitteesChartsPageModContentFactoryImpl: Implementation of the committee ranking all committees charts page mode content factory.
+ * - CommitteeRankingCommitteeByPartyChartsPageModContentFactoryImpl: Implementation of the committee ranking committee by party charts page mode content factory.
+ * - CommitteeRankingCurrentCommitteePartiesChartsPageModContentFactoryImpl: Implementation of the committee ranking current committee parties charts page mode content factory.
+ * - CommitteeRankingCurrentCommitteesChartsPageModContentFactoryImpl: Implementation of the committee ranking current committees charts page mode content factory.
+ * - CommitteeRankingDataGridPageModContentFactoryImpl: Implementation of the committee ranking data grid page mode content factory.
+ * - CommitteeRankingOverviewPageModContentFactoryImpl: Implementation of the committee ranking overview page mode content factory.
+ * - CommitteeRankingPageVisitHistoryPageModContentFactoryImpl: Implementation of the committee ranking page visit history page mode content factory.
+ *
+ * Dependencies and relationships:
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.pagemode for AbstractBasicPageModContentFactoryImpl.
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.viewnames for UserViews and CommitteeRankingPageMode.
+ * - Depends on com.hack23.cia.model.internal.application.data.committee.impl for ViewRiksdagenCommittee and related entities.
+ * - Depends on com.hack23.cia.service.api for data container and application manager services.
+ * - Depends on org.springframework.security.access.annotation for security annotations.
+ * - Depends on org.springframework.stereotype for component annotations.
+ * - Depends on com.vaadin.ui for UI components.
+ */
+package com.hack23.cia.web.impl.ui.application.views.user.committeeranking.pagemode;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbodyranking/package-info.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbodyranking/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * This package provides classes and interfaces for managing government body rankings within the Citizen Intelligence Agency web application.
+ *
+ * Key classes and interfaces:
+ * - GovernmentBodyRankingView: View class for displaying government body rankings.
+ *
+ * Dependencies and relationships:
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.pagemode for PageModeContentFactory.
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.viewnames for UserViews and GovernmentBodyRankingPageMode.
+ * - Depends on com.hack23.cia.model.internal.application.data.governmentbody.impl for ViewRiksdagenGovernmentBody and related entities.
+ * - Depends on com.hack23.cia.service.api for data container and application manager services.
+ * - Depends on org.springframework.security.access.annotation for security annotations.
+ * - Depends on org.springframework.stereotype for component annotations.
+ * - Depends on com.vaadin.ui for UI components.
+ */
+package com.hack23.cia.web.impl.ui.application.views.user.govermentbodyranking;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbodyranking/pagemode/package-info.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbodyranking/pagemode/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * This package provides classes and interfaces for managing page modes within government body ranking views.
+ *
+ * Key classes and interfaces:
+ * - AbstractGovernmentBodyRankingPageModContentFactoryImpl: Abstract base class for government body ranking page mode content factories.
+ * - GovernmentBodyRankingDataGridPageModContentFactoryImpl: Implementation of the government body ranking data grid page mode content factory.
+ * - GovernmentBodyRankingExpenditurePageModContentFactoryImpl: Implementation of the government body ranking expenditure page mode content factory.
+ * - GovernmentBodyRankingHeadCountPageModContentFactoryImpl: Implementation of the government body ranking head count page mode content factory.
+ * - GovernmentBodyRankingIncomePageModContentFactoryImpl: Implementation of the government body ranking income page mode content factory.
+ * - GovernmentBodyRankingOverviewPageModContentFactoryImpl: Implementation of the government body ranking overview page mode content factory.
+ * - GovernmentBodyRankingPageVisitHistoryPageModContentFactoryImpl: Implementation of the government body ranking page visit history page mode content factory.
+ *
+ * Dependencies and relationships:
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.pagemode for AbstractBasicPageModContentFactoryImpl.
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.viewnames for UserViews and GovernmentBodyRankingPageMode.
+ * - Depends on com.hack23.cia.model.internal.application.data.governmentbody.impl for ViewRiksdagenGovernmentBody and related entities.
+ * - Depends on com.hack23.cia.service.api for data container and application manager services.
+ * - Depends on org.springframework.security.access.annotation for security annotations.
+ * - Depends on org.springframework.stereotype for component annotations.
+ * - Depends on com.vaadin.ui for UI components.
+ */
+package com.hack23.cia.web.impl.ui.application.views.user.govermentbodyranking.pagemode;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/package-info.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * This package provides classes and interfaces for managing government rankings within the Citizen Intelligence Agency web application.
+ *
+ * Key classes and interfaces:
+ * - MinistryRankingView: View class for displaying ministry rankings.
+ *
+ * Dependencies and relationships:
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.pagemode for PageModeContentFactory.
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.viewnames for UserViews and MinistryRankingPageMode.
+ * - Depends on com.hack23.cia.model.internal.application.data.government.impl for ViewRiksdagenMinistry and related entities.
+ * - Depends on com.hack23.cia.service.api for data container and application manager services.
+ * - Depends on org.springframework.security.access.annotation for security annotations.
+ * - Depends on org.springframework.stereotype for component annotations.
+ * - Depends on com.vaadin.ui for UI components.
+ */
+package com.hack23.cia.web.impl.ui.application.views.user.govermentranking;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/package-info.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentranking/pagemode/package-info.java
@@ -1,0 +1,29 @@
+/**
+ * This package provides classes and interfaces for managing page modes within government ranking views.
+ *
+ * Key classes and interfaces:
+ * - AbstractMinistryRankingPageModContentFactoryImpl: Abstract base class for ministry ranking page mode content factories.
+ * - MinistryRankingAllMinistriesChartsPageModContentFactoryImpl: Implementation of the ministry ranking all ministries charts page mode content factory.
+ * - MinistryRankingAllPartiesChartsPageModContentFactoryImpl: Implementation of the ministry ranking all parties charts page mode content factory.
+ * - MinistryRankingAllRolesChartsPageModContentFactoryImpl: Implementation of the ministry ranking all roles charts page mode content factory.
+ * - MinistryRankingCurrentMinistriesChartsPageModContentFactoryImpl: Implementation of the ministry ranking current ministries charts page mode content factory.
+ * - MinistryRankingCurrentPartiesChartsPageModContentFactoryImpl: Implementation of the ministry ranking current parties charts page mode content factory.
+ * - MinistryRankingCurrentPartiesLeaderScoreboardChartsPageModContentFactoryImpl: Implementation of the ministry ranking current parties leader scoreboard charts page mode content factory.
+ * - MinistryRankingDataGridPageModContentFactoryImpl: Implementation of the ministry ranking data grid page mode content factory.
+ * - MinistryRankingGovernmentBodiesPageModContentFactoryImpl: Implementation of the ministry ranking government bodies page mode content factory.
+ * - MinistryRankingGovernmentBodyExpenditurePageModContentFactoryImpl: Implementation of the ministry ranking government body expenditure page mode content factory.
+ * - MinistryRankingGovernmentBodyIncomePageModContentFactoryImpl: Implementation of the ministry ranking government body income page mode content factory.
+ * - MinistryRankingGovernmentOutcomePageModContentFactoryImpl: Implementation of the ministry ranking government outcome page mode content factory.
+ * - MinistryRankingOverviewPageModContentFactoryImpl: Implementation of the ministry ranking overview page mode content factory.
+ * - MinistryRankingPageVisitHistoryPageModContentFactoryImpl: Implementation of the ministry ranking page visit history page mode content factory.
+ *
+ * Dependencies and relationships:
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.pagemode for AbstractBasicPageModContentFactoryImpl.
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.viewnames for UserViews and MinistryRankingPageMode.
+ * - Depends on com.hack23.cia.model.internal.application.data.government.impl for ViewRiksdagenMinistry and related entities.
+ * - Depends on com.hack23.cia.service.api for data container and application manager services.
+ * - Depends on org.springframework.security.access.annotation for security annotations.
+ * - Depends on org.springframework.stereotype for component annotations.
+ * - Depends on com.vaadin.ui for UI components.
+ */
+package com.hack23.cia.web.impl.ui.application.views.user.govermentranking.pagemode;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/package-info.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * This package provides classes and interfaces for managing party rankings within the Citizen Intelligence Agency web application.
+ *
+ * Key classes and interfaces:
+ * - PartyRankingView: View class for displaying party rankings.
+ *
+ * Dependencies and relationships:
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.pagemode for PageModeContentFactory.
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.viewnames for UserViews and PartyRankingPageMode.
+ * - Depends on com.hack23.cia.model.internal.application.data.party.impl for ViewRiksdagenParty and related entities.
+ * - Depends on com.hack23.cia.service.api for data container and application manager services.
+ * - Depends on org.springframework.security.access.annotation for security annotations.
+ * - Depends on org.springframework.stereotype for component annotations.
+ * - Depends on com.vaadin.ui for UI components.
+ */
+package com.hack23.cia.web.impl.ui.application.views.user.partyranking;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/package-info.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/partyranking/pagemode/package-info.java
@@ -1,0 +1,24 @@
+/**
+ * This package provides classes and interfaces for managing page modes within party ranking views.
+ *
+ * Key classes and interfaces:
+ * - AbstractPartyRankingPageModContentFactoryImpl: Abstract base class for party ranking page mode content factories.
+ * - PartyRankingAllPartiesChartsPageModContentFactoryImpl: Implementation of the party ranking all parties charts page mode content factory.
+ * - PartyRankingCurrentCommitteeChartsPageModContentFactoryImpl: Implementation of the party ranking current committee charts page mode content factory.
+ * - PartyRankingCurrentGovernmentChartsPageModContentFactoryImpl: Implementation of the party ranking current government charts page mode content factory.
+ * - PartyRankingCurrentPartiesChartsPageModContentFactoryImpl: Implementation of the party ranking current parties charts page mode content factory.
+ * - PartyRankingCurrentPartiesLeaderScoreboardPageModContentFactoryImpl: Implementation of the party ranking current parties leader scoreboard page mode content factory.
+ * - PartyRankingDataGridPageModContentFactoryImpl: Implementation of the party ranking data grid page mode content factory.
+ * - PartyRankingOverviewPageModContentFactoryImpl: Implementation of the party ranking overview page mode content factory.
+ * - PartyRankingPageVisitHistoryPageModContentFactoryImpl: Implementation of the party ranking page visit history page mode content factory.
+ *
+ * Dependencies and relationships:
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.pagemode for AbstractBasicPageModContentFactoryImpl.
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.viewnames for UserViews and PartyRankingPageMode.
+ * - Depends on com.hack23.cia.model.internal.application.data.party.impl for ViewRiksdagenParty and related entities.
+ * - Depends on com.hack23.cia.service.api for data container and application manager services.
+ * - Depends on org.springframework.security.access.annotation for security annotations.
+ * - Depends on org.springframework.stereotype for component annotations.
+ * - Depends on com.vaadin.ui for UI components.
+ */
+package com.hack23.cia.web.impl.ui.application.views.user.partyranking.pagemode;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/politicianranking/package-info.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/politicianranking/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * This package provides classes and interfaces for managing politician rankings within the Citizen Intelligence Agency web application.
+ *
+ * Key classes and interfaces:
+ * - PoliticianRankingView: View class for displaying politician rankings.
+ *
+ * Dependencies and relationships:
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.pagemode for PageModeContentFactory.
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.viewnames for UserViews and PoliticianRankingPageMode.
+ * - Depends on com.hack23.cia.model.internal.application.data.politician.impl for ViewRiksdagenPolitician and related entities.
+ * - Depends on com.hack23.cia.service.api for data container and application manager services.
+ * - Depends on org.springframework.security.access.annotation for security annotations.
+ * - Depends on org.springframework.stereotype for component annotations.
+ * - Depends on com.vaadin.ui for UI components.
+ */
+package com.hack23.cia.web.impl.ui.application.views.user.politicianranking;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/politicianranking/pagemode/package-info.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/politicianranking/pagemode/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * This package provides classes and interfaces for managing page modes within politician ranking views.
+ *
+ * Key classes and interfaces:
+ * - AbstractPoliticianRankingPageModContentFactoryImpl: Abstract base class for politician ranking page mode content factories.
+ * - PoliticianRankingAllPoliticiansChartsPageModContentFactoryImpl: Implementation of the politician ranking all politicians charts page mode content factory.
+ * - PoliticianRankingCurrentPoliticiansChartsPageModContentFactoryImpl: Implementation of the politician ranking current politicians charts page mode content factory.
+ * - PoliticianRankingDataGridPageModContentFactoryImpl: Implementation of the politician ranking data grid page mode content factory.
+ * - PoliticianRankingOverviewPageModContentFactoryImpl: Implementation of the politician ranking overview page mode content factory.
+ * - PoliticianRankingPageVisitHistoryPageModContentFactoryImpl: Implementation of the politician ranking page visit history page mode content factory.
+ *
+ * Dependencies and relationships:
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.pagemode for AbstractBasicPageModContentFactoryImpl.
+ * - Depends on com.hack23.cia.web.impl.ui.application.views.common.viewnames for UserViews and PoliticianRankingPageMode.
+ * - Depends on com.hack23.cia.model.internal.application.data.politician.impl for ViewRiksdagenPolitician and related entities.
+ * - Depends on com.hack23.cia.service.api for data container and application manager services.
+ * - Depends on org.springframework.security.access.annotation for security annotations.
+ * - Depends on org.springframework.stereotype for component annotations.
+ * - Depends on com.vaadin.ui for UI components.
+ */
+package com.hack23.cia.web.impl.ui.application.views.user.politicianranking.pagemode;


### PR DESCRIPTION
Add package-info.java files to new packages under `citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user`.

* Add `package-info.java` to `committeeranking` package.
* Add `package-info.java` to `committeeranking.pagemode` package.
* Add `package-info.java` to `govermentbodyranking` package.
* Add `package-info.java` to `govermentbodyranking.pagemode` package.
* Add `package-info.java` to `govermentranking` package.
* Add `package-info.java` to `govermentranking.pagemode` package.
* Add `package-info.java` to `partyranking` package.
* Add `package-info.java` to `partyranking.pagemode` package.
* Add `package-info.java` to `politicianranking` package.
* Add `package-info.java` to `politicianranking.pagemode` package.

Enhance `CommitteeRankingConstants.java` with detailed Javadoc comments.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/cia/pull/7122?shareId=159a4064-5aae-4e5c-8095-f44d4f086511).