### PR TITLE
Refactor page matching logic and menu item commands

### DIFF
--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandGovernmentBodyConstants.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandGovernmentBodyConstants.java
@@ -1,6 +1,7 @@
 package com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands;
 
 import com.hack23.cia.web.impl.ui.application.views.common.pagelinks.api.PageModeMenuCommand;
+import com.hack23.cia.web.impl.ui.application.views.common.viewnames.GovernmentBodyPageMode;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PageMode;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 
@@ -11,29 +12,22 @@ public interface PageCommandGovernmentBodyConstants {
 
     /** The government body command expenditure. */
     PageModeMenuCommand COMMAND_GOVERNMENT_BODY_EXPENDITURE = new PageModeMenuCommand(
-                     UserViews.GOVERNMENT_BODY_VIEW_NAME, "expenditure");
+                     UserViews.GOVERNMENT_BODY_VIEW_NAME, GovernmentBodyPageMode.EXPENDITURE.toString());
 
     /** The government body command headcount. */
     PageModeMenuCommand COMMAND_GOVERNMENT_BODY_HEADCOUNT = new PageModeMenuCommand(
-                     UserViews.GOVERNMENT_BODY_VIEW_NAME, "headcount");
+                     UserViews.GOVERNMENT_BODY_VIEW_NAME, GovernmentBodyPageMode.HEADCOUNT.toString());
 
     /** The government body command income. */
     PageModeMenuCommand COMMAND_GOVERNMENT_BODY_INCOME = new PageModeMenuCommand(
-                     UserViews.GOVERNMENT_BODY_VIEW_NAME, "income");
+                     UserViews.GOVERNMENT_BODY_VIEW_NAME, GovernmentBodyPageMode.INCOME.toString());
 
     /** The government body command overview. */
     PageModeMenuCommand COMMAND_GOVERNMENT_BODY_OVERVIEW = new PageModeMenuCommand(
                      UserViews.GOVERNMENT_BODY_VIEW_NAME, PageMode.OVERVIEW);
 
-    /** The command government body headcount. */
-    PageModeMenuCommand COMMAND_GOVERNMENT_BODIES_HEADCOUNT = new PageModeMenuCommand(
-        UserViews.GOVERNMENT_BODY_VIEW_NAME, PageMode.CHARTS, "GOVERNMENT_BODIES_HEADCOUNT");
 
-    /** The command government body income. */
-    PageModeMenuCommand COMMAND_GOVERNMENT_BODIES_INCOME = new PageModeMenuCommand(
-        UserViews.GOVERNMENT_BODY_VIEW_NAME, PageMode.CHARTS, "GOVERNMENT_BODIES_INCOME");
+     PageModeMenuCommand COMMAND_GOVERNMENT_BODY_PAGEVISIT = new PageModeMenuCommand(
+            UserViews.GOVERNMENT_BODY_VIEW_NAME, PageMode.PAGEVISITHISTORY);
 
-    /** The command government body expenditure. */
-    PageModeMenuCommand COMMAND_GOVERNMENT_BODIES_EXPENDITURE = new PageModeMenuCommand(
-        UserViews.GOVERNMENT_BODY_VIEW_NAME, PageMode.CHARTS, "GOVERNMENT_BODIES_EXPENDITURE");
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/BallotMenuItemFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/BallotMenuItemFactoryImpl.java
@@ -66,9 +66,9 @@ public final class BallotMenuItemFactoryImpl extends AbstractMenuItemFactoryImpl
 		initApplicationMenuBar(menuBar);
 
 		menuBar.addItem(OVERVIEW_TEXT, VaadinIcons.PIE_CHART,
-				PageCommandBallotConstants.COMMAND_BALLOT_OVERVIEW);
+				PageCommandBallotConstants.COMMAND_BALLOT_OVERVIEW.createItemPageCommand(pageId));
 		menuBar.addItem(CHARTS_TEXT, VaadinIcons.PIE_CHART,
-				PageCommandBallotConstants.COMMAND_BALLOT_CHARTS);
+				PageCommandBallotConstants.COMMAND_BALLOT_CHARTS.createItemPageCommand(pageId));
 	}
 
 	/**
@@ -82,7 +82,7 @@ public final class BallotMenuItemFactoryImpl extends AbstractMenuItemFactoryImpl
 		final ResponsiveRow grid = RowUtil.createGridLayout(panelContent);
 
 		createButtonLink(grid, CHARTS_TEXT, VaadinIcons.PIE_CHART,
-				PageCommandBallotConstants.COMMAND_BALLOT_CHARTS, BALLOT_RESULTS_DESCRIPTION);
+				PageCommandBallotConstants.COMMAND_BALLOT_CHARTS.createItemPageCommand(pageId), BALLOT_RESULTS_DESCRIPTION);
 	}
 
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/GovernmentBodyMenuItemFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/GovernmentBodyMenuItemFactoryImpl.java
@@ -48,16 +48,16 @@ public final class GovernmentBodyMenuItemFactoryImpl extends AbstractMenuItemFac
         final MenuItem governmentBodyItem = menuBar.addItem(title, VaadinIcons.BUILDING_O, null);
 
         governmentBodyItem.addItem(GOVERNMENT_BODY_OVERVIEW_TEXT, VaadinIcons.FILE_TEXT,
-                PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_OVERVIEW);
+                PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_OVERVIEW.createItemPageCommand(pageId));
 
         governmentBodyItem.addItem(HEADCOUNT_CHART, VaadinIcons.USER,
-                PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_HEADCOUNT);
+                PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_HEADCOUNT.createItemPageCommand(pageId));
 
         governmentBodyItem.addItem(INCOME, VaadinIcons.MONEY,
-                PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_INCOME);
+                PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_INCOME.createItemPageCommand(pageId));
 
         governmentBodyItem.addItem(EXPENDITURE, VaadinIcons.CREDIT_CARD,
-                PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_EXPENDITURE);
+                PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_EXPENDITURE.createItemPageCommand(pageId));
     }
 
     @Override
@@ -65,15 +65,15 @@ public final class GovernmentBodyMenuItemFactoryImpl extends AbstractMenuItemFac
         final ResponsiveRow grid = RowUtil.createGridLayout(panelContent);
 
         createButtonLink(grid, HEADCOUNT_CHART, VaadinIcons.USER,
-                PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_HEADCOUNT,
+                PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_HEADCOUNT.createItemPageCommand(pageId),
                 HEADCOUNT_DESCRIPTION);
 
         createButtonLink(grid, INCOME, VaadinIcons.MONEY,
-                PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_INCOME,
+                PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_INCOME.createItemPageCommand(pageId),
                 INCOME_DESCRIPTION);
 
         createButtonLink(grid, EXPENDITURE, VaadinIcons.CREDIT_CARD,
-                PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_EXPENDITURE,
+                PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_EXPENDITURE.createItemPageCommand(pageId),
                 EXPENDITURE_DESCRIPTION);
     }
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/GovernmentBodyRankingMenuItemFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/GovernmentBodyRankingMenuItemFactoryImpl.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Service;
 
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.ApplicationMenuItemFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.GovernmentBodyRankingMenuItemFactory;
-import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandGovernmentBodyConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandGovernmentBodyRankingConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.rows.RowUtil;
 import com.jarektoro.responsivelayout.ResponsiveRow;
@@ -92,7 +91,7 @@ public final class GovernmentBodyRankingMenuItemFactoryImpl extends AbstractMenu
                 menuItem.addItem(OVERVIEW_TEXT, VaadinIcons.DASHBOARD, COMMAND_GOVERNMENT_BODY_RANKING_OVERVIEW);
                 menuItem.addItem(GOVERNMENT_BODIES, VaadinIcons.BUILDING_O, PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODY_RANKING_DATAGRID);
                 menuItem.addItem(GOVERNMENT_BODIES_HEADCOUNT, VaadinIcons.USER_CHECK,
-                		PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODIES_HEADCOUNT);
+                PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODIES_HEADCOUNT);
                 menuItem.addItem(GOVERNMENT_BODIES_INCOME, VaadinIcons.MONEY, PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODIES_INCOME);
                 menuItem.addItem(GOVERNMENT_BODIES_EXPENDITURE, VaadinIcons.MONEY_WITHDRAW,
                 		PageCommandGovernmentBodyRankingConstants.COMMAND_GOVERNMENT_BODIES_EXPENDITURE);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyExpenditurePageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyExpenditurePageModContentFactoryImpl.java
@@ -20,7 +20,6 @@ package com.hack23.cia.web.impl.ui.application.views.user.govermentbody.pagemode
 
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Component;
@@ -29,8 +28,8 @@ import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGro
 import com.hack23.cia.service.external.esv.api.GovernmentBodyAnnualSummary;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
 import com.hack23.cia.web.impl.ui.application.views.common.chartfactory.api.GovernmentBodyChartDataManager;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandGovernmentBodyConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.pagemode.CardInfoRowUtil;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.GovernmentBodyPageMode;
 import com.vaadin.ui.Layout;
 import com.vaadin.ui.MenuBar;
 import com.vaadin.ui.Panel;
@@ -89,7 +88,8 @@ public final class GovernmentBodyExpenditurePageModContentFactoryImpl extends Ab
 
 	@Override
 	public boolean matches(final String page, final String parameters) {
-		return NAME.equals(page) && StringUtils.contains(parameters, GovernmentBodyPageMode.EXPENDITURE.toString());
+		return  PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_EXPENDITURE.matches(page, parameters);
+
 	}
 
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyHeadcountPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyHeadcountPageModContentFactoryImpl.java
@@ -20,7 +20,6 @@ package com.hack23.cia.web.impl.ui.application.views.user.govermentbody.pagemode
 
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Component;
@@ -29,8 +28,8 @@ import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGro
 import com.hack23.cia.service.external.esv.api.GovernmentBodyAnnualSummary;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
 import com.hack23.cia.web.impl.ui.application.views.common.chartfactory.api.GovernmentBodyChartDataManager;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandGovernmentBodyConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.pagemode.CardInfoRowUtil;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.GovernmentBodyPageMode;
 import com.vaadin.ui.Layout;
 import com.vaadin.ui.MenuBar;
 import com.vaadin.ui.Panel;
@@ -84,7 +83,7 @@ public final class GovernmentBodyHeadcountPageModContentFactoryImpl extends Abst
 
 	@Override
 	public boolean matches(final String page, final String parameters) {
-		return NAME.equals(page) && StringUtils.contains(parameters, GovernmentBodyPageMode.HEADCOUNT.toString());
+		return  PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_HEADCOUNT.matches(page, parameters);
 	}
 
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyIncomePageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyIncomePageModContentFactoryImpl.java
@@ -20,7 +20,6 @@ package com.hack23.cia.web.impl.ui.application.views.user.govermentbody.pagemode
 
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Component;
@@ -29,8 +28,8 @@ import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGro
 import com.hack23.cia.service.external.esv.api.GovernmentBodyAnnualSummary;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
 import com.hack23.cia.web.impl.ui.application.views.common.chartfactory.api.GovernmentBodyChartDataManager;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandGovernmentBodyConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.pagemode.CardInfoRowUtil;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.GovernmentBodyPageMode;
 import com.vaadin.ui.Layout;
 import com.vaadin.ui.MenuBar;
 import com.vaadin.ui.Panel;
@@ -86,7 +85,7 @@ public final class GovernmentBodyIncomePageModContentFactoryImpl extends Abstrac
 
 	@Override
 	public boolean matches(final String page, final String parameters) {
-		return NAME.equals(page) && StringUtils.contains(parameters, GovernmentBodyPageMode.INCOME.toString());
+		return  PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_INCOME.matches(page, parameters);
 	}
 
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyOverviewPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyOverviewPageModContentFactoryImpl.java
@@ -20,16 +20,15 @@ package com.hack23.cia.web.impl.ui.application.views.user.govermentbody.pagemode
 
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Component;
 
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.service.external.esv.api.GovernmentBodyAnnualSummary;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandGovernmentBodyConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.pagemode.CardInfoRowUtil;
 import com.hack23.cia.web.impl.ui.application.views.common.sizing.ContentRatio;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PageMode;
 import com.vaadin.icons.VaadinIcons;
 import com.vaadin.server.Responsive;
 import com.vaadin.ui.HorizontalLayout;
@@ -291,10 +290,7 @@ public final class GovernmentBodyOverviewPageModContentFactoryImpl
 
 	@Override
 	public boolean matches(final String page, final String parameters) {
-		final String pageId = getPageId(parameters);
-		return NAME.equals(page) && (StringUtils.isEmpty(parameters) || parameters.equals(pageId)
-
-				|| parameters.contains(PageMode.OVERVIEW.toString()));
+		return  PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_OVERVIEW.matches(page, parameters);
 	}
 
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyPageVisitHistoryPageModContentFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/user/govermentbody/pagemode/GovernmentBodyPageVisitHistoryPageModContentFactoryImpl.java
@@ -18,14 +18,13 @@
 */
 package com.hack23.cia.web.impl.ui.application.views.user.govermentbody.pagemode;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Component;
 
 import com.hack23.cia.model.internal.application.system.impl.ApplicationEventGroup;
 import com.hack23.cia.web.impl.ui.application.action.ViewAction;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandGovernmentBodyConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.pagemode.CardInfoRowUtil;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PageMode;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 import com.vaadin.ui.Layout;
 import com.vaadin.ui.MenuBar;
@@ -75,7 +74,7 @@ public final class GovernmentBodyPageVisitHistoryPageModContentFactoryImpl
 
 	@Override
 	public boolean matches(final String page, final String parameters) {
-		return NAME.equals(page) && StringUtils.contains(parameters,PageMode.PAGEVISITHISTORY.toString());
+		return  PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_PAGEVISIT.matches(page, parameters);
 	}
 
 }

--- a/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/governmentbody/UserGovernmentBodyTest.java
+++ b/citizen-intelligence-agency/src/test/java/com/hack23/cia/systemintegrationtest/user/governmentbody/UserGovernmentBodyTest.java
@@ -1,14 +1,69 @@
 package com.hack23.cia.systemintegrationtest.user.governmentbody;
 
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import com.hack23.cia.systemintegrationtest.AbstractUITest;
 import com.hack23.cia.systemintegrationtest.categories.IntegrationTest;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandGovernmentBodyConstants;
+import com.hack23.cia.web.impl.ui.application.views.user.govermentbody.pagemode.GovernmentBodyDescriptionConstants;
 
 /**
  * The Class UserGovernmentBodyTest.
  */
 @Category(IntegrationTest.class)
 public final class UserGovernmentBodyTest extends AbstractUITest {
+
+    private static final String GOV_BODY_ID = "202100-4979";
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyGovernmentBodyOverviewPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_OVERVIEW.createItemPageCommand(GOV_BODY_ID));
+        pageVisit.verifyViewContent(
+                GovernmentBodyDescriptionConstants.OVERVIEW_HEADER,
+                GovernmentBodyDescriptionConstants.OVERVIEW_SUBTITLE,
+                GovernmentBodyDescriptionConstants.OVERVIEW_DESC);
+        pageVisit.validatePage(PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_OVERVIEW.createItemPageCommand(GOV_BODY_ID));
+    }
+    
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyGovernmentBodyHeadcountPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_HEADCOUNT.createItemPageCommand(GOV_BODY_ID));
+        pageVisit.verifyViewContent(
+                GovernmentBodyDescriptionConstants.HEADCOUNT_HEADER,
+                GovernmentBodyDescriptionConstants.HEADCOUNT_SUBTITLE,
+                GovernmentBodyDescriptionConstants.HEADCOUNT_DESC);
+        pageVisit.validatePage(PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_HEADCOUNT.createItemPageCommand(GOV_BODY_ID));
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyGovernmentBodyIncomePage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_INCOME.createItemPageCommand(GOV_BODY_ID));
+        pageVisit.verifyViewContent(
+                GovernmentBodyDescriptionConstants.INCOME_HEADER,
+                GovernmentBodyDescriptionConstants.INCOME_SUBTITLE,
+                GovernmentBodyDescriptionConstants.INCOME_DESC);
+        pageVisit.validatePage(PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_INCOME.createItemPageCommand(GOV_BODY_ID));
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyGovernmentBodyExpenditurePage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_EXPENDITURE.createItemPageCommand(GOV_BODY_ID));
+        pageVisit.verifyViewContent(
+                GovernmentBodyDescriptionConstants.EXPENDITURE_HEADER,
+                GovernmentBodyDescriptionConstants.EXPENDITURE_SUBTITLE,
+                GovernmentBodyDescriptionConstants.EXPENDITURE_DESC);
+        pageVisit.validatePage(PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_EXPENDITURE.createItemPageCommand(GOV_BODY_ID));
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void verifyGovernmentBodyPageVisitPage() throws Exception {
+        pageVisit.visitDirectPage(PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_PAGEVISIT.createItemPageCommand(GOV_BODY_ID));
+        pageVisit.verifyViewContent(
+                GovernmentBodyDescriptionConstants.VISIT_HISTORY_HEADER,
+                GovernmentBodyDescriptionConstants.VISIT_HISTORY_SUBTITLE,
+                GovernmentBodyDescriptionConstants.VISIT_HISTORY_DESC);
+        pageVisit.validatePage(PageCommandGovernmentBodyConstants.COMMAND_GOVERNMENT_BODY_PAGEVISIT.createItemPageCommand(GOV_BODY_ID));
+    }
 
 }


### PR DESCRIPTION
Replace `StringUtils` with `PageCommandGovernmentBodyConstants` for improved page matching logic and update menu item commands to include page ID for government body and ballot menus.