### PR TITLE
Refactor menu factory implementations to use constants

### DIFF
--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandCommitteeConstants.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandCommitteeConstants.java
@@ -2,6 +2,7 @@ package com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.page
 
 import com.hack23.cia.web.impl.ui.application.views.common.pagelinks.api.PageModeMenuCommand;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.ChartIndicators;
+import com.hack23.cia.web.impl.ui.application.views.common.viewnames.CommitteePageMode;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PageMode;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 
@@ -9,7 +10,6 @@ import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
  * The Interface PageCommandCommitteeConstants.
  */
 public interface PageCommandCommitteeConstants {
-
 
     /** The command committee overview. */
     PageModeMenuCommand COMMAND_COMMITTEE_OVERVIEW = new PageModeMenuCommand(
@@ -28,4 +28,31 @@ public interface PageCommandCommitteeConstants {
             UserViews.COMMITTEE_VIEW_NAME, PageMode.CHARTS,
             ChartIndicators.DECISION_FLOW_CHART.toString());
 
+    /** The command committee current members. */
+    PageModeMenuCommand COMMAND_COMMITTEE_CURRENT_MEMBERS = new PageModeMenuCommand(
+            UserViews.COMMITTEE_VIEW_NAME, CommitteePageMode.CURRENT_MEMBERS.toString());
+
+    /** The command committee member history. */
+    PageModeMenuCommand COMMAND_COMMITTEE_MEMBER_HISTORY = new PageModeMenuCommand(
+            UserViews.COMMITTEE_VIEW_NAME, CommitteePageMode.MEMBERHISTORY.toString());
+
+    /** The command committee document activity. */
+    PageModeMenuCommand COMMAND_COMMITTEE_DOCUMENT_ACTIVITY = new PageModeMenuCommand(
+            UserViews.COMMITTEE_VIEW_NAME, CommitteePageMode.DOCUMENTACTIVITY.toString());
+
+    /** The command committee document history. */
+    PageModeMenuCommand COMMAND_COMMITTEE_DOCUMENT_HISTORY = new PageModeMenuCommand(
+            UserViews.COMMITTEE_VIEW_NAME, CommitteePageMode.DOCUMENT_HISTORY.toString());
+
+    /** The command committee ballot decision summary. */
+    PageModeMenuCommand COMMAND_COMMITTEE_BALLOT_DECISION_SUMMARY = new PageModeMenuCommand(
+            UserViews.COMMITTEE_VIEW_NAME, CommitteePageMode.BALLOTDECISIONSUMMARY.toString());
+
+    /** The command committee decision summary. */
+    PageModeMenuCommand COMMAND_COMMITTEE_DECISION_SUMMARY = new PageModeMenuCommand(
+            UserViews.COMMITTEE_VIEW_NAME, CommitteePageMode.DECISIONSUMMARY.toString());
+
+    /** The command committee decision type daily summary. */
+    PageModeMenuCommand COMMAND_COMMITTEE_DECISION_TYPE_DAILY_SUMMARY = new PageModeMenuCommand(
+            UserViews.COMMITTEE_VIEW_NAME, CommitteePageMode.DECISIONTYPEDAILYSUMMARY.toString());
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandMainViewConstants.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandMainViewConstants.java
@@ -12,7 +12,7 @@ import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 public interface PageCommandMainViewConstants {
 
 	/** The command userhome. */
-	PageModeMenuCommand COMMAND_USERHOME = new PageModeMenuCommand(UserViews.USERHOME_VIEW_NAME, "");
+	PageModeMenuCommand COMMAND_USERHOME = new PageModeMenuCommand(UserViews.USERHOME_VIEW_NAME, PageMode.OVERVIEW);
 
 	/** The command mainview overview. */
 	PageModeMenuCommand COMMAND_MAINVIEW_OVERVIEW = new PageModeMenuCommand(CommonsViews.MAIN_VIEW_NAME,PageMode.OVERVIEW);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandMinistryConstants.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandMinistryConstants.java
@@ -2,6 +2,7 @@ package com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.page
 
 import com.hack23.cia.web.impl.ui.application.views.common.pagelinks.api.PageModeMenuCommand;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.ChartIndicators;
+import com.hack23.cia.web.impl.ui.application.views.common.viewnames.MinistryPageMode;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PageMode;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 
@@ -17,5 +18,32 @@ public interface PageCommandMinistryConstants {
 	/** The ministry command pagevisithistory. */
 	PageModeMenuCommand MINISTRY_COMMAND_PAGEVISITHISTORY = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
 			PageMode.PAGEVISITHISTORY);
+
+	/** The command ministry overview. */
+	PageModeMenuCommand COMMAND_MINISTRY_OVERVIEW = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, PageMode.OVERVIEW);
+
+	/** The command ministry current members. */
+	PageModeMenuCommand COMMAND_MINISTRY_CURRENT_MEMBERS = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, MinistryPageMode.CURRENTMEMBERS.toString());
+
+	/** The command ministry member history. */
+	PageModeMenuCommand COMMAND_MINISTRY_MEMBER_HISTORY = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, MinistryPageMode.MEMBERHISTORY.toString());
+
+	/** The command ministry role ghant. */
+	PageModeMenuCommand COMMAND_MINISTRY_ROLE_GHANT = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, MinistryPageMode.ROLEGHANT.toString());
+
+	/** The command ministry government bodies headcount. */
+	PageModeMenuCommand COMMAND_MINISTRY_GOVERNMENT_BODIES_HEADCOUNT = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, MinistryPageMode.GOVERNMENT_BODIES_HEADCOUNT.toString());
+
+	/** The command ministry government bodies income. */
+	PageModeMenuCommand COMMAND_MINISTRY_GOVERNMENT_BODIES_INCOME = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, MinistryPageMode.GOVERNMENT_BODIES_INCOME.toString());
+
+	/** The command ministry government bodies expenditure. */
+	PageModeMenuCommand COMMAND_MINISTRY_GOVERNMENT_BODIES_EXPENDITURE = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, MinistryPageMode.GOVERNMENT_BODIES_EXPENDITURE.toString());
+
+	/** The command ministry document activity. */
+	PageModeMenuCommand COMMAND_MINISTRY_DOCUMENT_ACTIVITY = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, MinistryPageMode.DOCUMENTACTIVITY.toString());
+
+	/** The command ministry document history. */
+	PageModeMenuCommand COMMAND_MINISTRY_DOCUMENT_HISTORY = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, MinistryPageMode.DOCUMENTHISTORY.toString());
 
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandMinistryConstants.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandMinistryConstants.java
@@ -17,7 +17,7 @@ public interface PageCommandMinistryConstants {
 
 	/** The ministry command pagevisithistory. */
 	PageModeMenuCommand MINISTRY_COMMAND_PAGEVISITHISTORY = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-			"visitHistory");
+			PageMode.PAGEVISITHISTORY);
 
 	/** The command ministry overview. */
 	PageModeMenuCommand COMMAND_MINISTRY_OVERVIEW = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, PageMode.OVERVIEW);

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandMinistryConstants.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandMinistryConstants.java
@@ -17,7 +17,7 @@ public interface PageCommandMinistryConstants {
 
 	/** The ministry command pagevisithistory. */
 	PageModeMenuCommand MINISTRY_COMMAND_PAGEVISITHISTORY = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-			PageMode.PAGEVISITHISTORY);
+			"visitHistory");
 
 	/** The command ministry overview. */
 	PageModeMenuCommand COMMAND_MINISTRY_OVERVIEW = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, PageMode.OVERVIEW);
@@ -45,5 +45,8 @@ public interface PageCommandMinistryConstants {
 
 	/** The command ministry document history. */
 	PageModeMenuCommand COMMAND_MINISTRY_DOCUMENT_HISTORY = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, MinistryPageMode.DOCUMENTHISTORY.toString());
+
+	/** The command ministry page visit history. */
+	PageModeMenuCommand COMMAND_MINISTRY_PAGEVISIT_HISTORY = new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, "visitHistory");
 
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandPartyConstants.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandPartyConstants.java
@@ -1,8 +1,61 @@
 package com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands;
 
+import com.hack23.cia.web.impl.ui.application.views.common.pagelinks.api.PageModeMenuCommand;
+import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PageMode;
+import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PartyPageMode;
+import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
+
 /**
  * The Interface PageCommandPartyConstants.
  */
 public interface PageCommandPartyConstants {
+
+    /** The command party overview. */
+    PageModeMenuCommand COMMAND_PARTY_OVERVIEW = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PageMode.OVERVIEW);
+
+    /** The command party current leaders. */
+    PageModeMenuCommand COMMAND_PARTY_CURRENT_LEADERS = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.CURRENTLEADERS.toString());
+
+    /** The command party leader history. */
+    PageModeMenuCommand COMMAND_PARTY_LEADER_HISTORY = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.LEADERHISTORY.toString());
+
+    /** The command party current members. */
+    PageModeMenuCommand COMMAND_PARTY_CURRENT_MEMBERS = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.CURRENTMEMBERS.toString());
+
+    /** The command party member history. */
+    PageModeMenuCommand COMMAND_PARTY_MEMBER_HISTORY = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.MEMBERHISTORY.toString());
+
+    /** The command party government roles. */
+    PageModeMenuCommand COMMAND_PARTY_GOVERNMENT_ROLES = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.GOVERNMENTROLES.toString());
+
+    /** The command party committee roles. */
+    PageModeMenuCommand COMMAND_PARTY_COMMITTEE_ROLES = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.COMMITTEEROLES.toString());
+
+    /** The command party role ghant. */
+    PageModeMenuCommand COMMAND_PARTY_ROLE_GHANT = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.ROLEGHANT.toString());
+
+    /** The command party document activity. */
+    PageModeMenuCommand COMMAND_PARTY_DOCUMENT_ACTIVITY = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.DOCUMENTACTIVITY.toString());
+
+    /** The command party document history. */
+    PageModeMenuCommand COMMAND_PARTY_DOCUMENT_HISTORY = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.DOCUMENTHISTORY.toString());
+
+    /** The command party vote history. */
+    PageModeMenuCommand COMMAND_PARTY_VOTE_HISTORY = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.VOTEHISTORY.toString());
+
+    /** The command party ballot decision summary. */
+    PageModeMenuCommand COMMAND_PARTY_BALLOT_DECISION_SUMMARY = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.COMMITTEEBALLOTDECISIONSUMMARY.toString());
+
+    /** The command party won daily summary chart. */
+    PageModeMenuCommand COMMAND_PARTY_WON_DAILY_SUMMARY_CHART = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.PARTYWONDAILYSUMMARYCHART.toString());
+
+    /** The command party against coalitions summary. */
+    PageModeMenuCommand COMMAND_PARTY_AGAINST_COALITIONS_SUMMARY = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.PARTYAGAINSTCOALATIONSSUMMARY.toString());
+
+    /** The command party support summary. */
+    PageModeMenuCommand COMMAND_PARTY_SUPPORT_SUMMARY = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.PARTYSUPPORTSUMMARY.toString());
+
+    /** The command party page visit history. */
+    PageModeMenuCommand COMMAND_PARTY_PAGE_VISIT_HISTORY = new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PageMode.PAGEVISITHISTORY);
 
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandPoliticianConstants.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandPoliticianConstants.java
@@ -1,7 +1,7 @@
 package com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands;
 
 import com.hack23.cia.web.impl.ui.application.views.common.pagelinks.api.PageModeMenuCommand;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PageMode;
+import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PoliticianPageMode; // updated import
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 
 /**
@@ -11,11 +11,11 @@ public interface PageCommandPoliticianConstants {
 
     /** The command politician ranking overview. */
     PageModeMenuCommand COMMAND_POLITICIAN_RANKING_OVERVIEW = new PageModeMenuCommand(
-        UserViews.POLITICIAN_RANKING_VIEW_NAME, PageMode.OVERVIEW);
+        UserViews.POLITICIAN_RANKING_VIEW_NAME, "overview");
 
     /** The command politician view. */
     PageModeMenuCommand COMMAND_POLITICIAN_VIEW = new PageModeMenuCommand(
-        UserViews.POLITICIAN_VIEW_NAME, PageMode.OVERVIEW);
+        UserViews.POLITICIAN_VIEW_NAME, "overview");
 
     /** The command politician ballot history. */
     PageModeMenuCommand COMMAND_POLITICIAN_BALLOT_HISTORY = new PageModeMenuCommand(
@@ -27,19 +27,30 @@ public interface PageCommandPoliticianConstants {
 
     /** The command politicians link. */
     PageModeMenuCommand COMMAND_POLITICIANS_LINK = new PageModeMenuCommand(
-            UserViews.POLITICIAN_RANKING_VIEW_NAME, PageMode.OVERVIEW);
+            UserViews.POLITICIAN_RANKING_VIEW_NAME, "overview");
 
     /** The command politician view overview. */
     PageModeMenuCommand COMMAND_POLITICIAN_VIEW_OVERVIEW = new PageModeMenuCommand(
-            UserViews.POLITICIAN_VIEW_NAME, PageMode.OVERVIEW);
+            UserViews.POLITICIAN_VIEW_NAME, "overview");
 
-        /** The command politician view indicators. */
-        PageModeMenuCommand COMMAND_POLITICIAN_VIEW_INDICATORS = new PageModeMenuCommand(
-            UserViews.POLITICIAN_VIEW_NAME, PageMode.INDICATORS);
+    /** The command politician view indicators. */
+    PageModeMenuCommand COMMAND_POLITICIAN_VIEW_INDICATORS = new PageModeMenuCommand(
+            UserViews.POLITICIAN_VIEW_NAME, "indicators");
 
-        /** The command politician view roles. */
-        PageModeMenuCommand COMMAND_POLITICIAN_VIEW_ROLES = new PageModeMenuCommand(
+    /** The command politician view roles. */
+    PageModeMenuCommand COMMAND_POLITICIAN_VIEW_ROLES = new PageModeMenuCommand(
             UserViews.POLITICIAN_VIEW_NAME, "roles");
 
+    /** The command politician role summary. */
+    PageModeMenuCommand COMMAND_POLITICIAN_ROLE_SUMMARY = new PageModeMenuCommand(
+            UserViews.POLITICIAN_VIEW_NAME, PoliticianPageMode.ROLESUMMARY.toString());
+
+    /** The command politician role list. */
+    PageModeMenuCommand COMMAND_POLITICIAN_ROLE_LIST = new PageModeMenuCommand(
+            UserViews.POLITICIAN_VIEW_NAME, PoliticianPageMode.ROLELIST.toString());
+
+    /** The command politician role ghant. */
+    PageModeMenuCommand COMMAND_POLITICIAN_ROLE_GHANT = new PageModeMenuCommand(
+            UserViews.POLITICIAN_VIEW_NAME, PoliticianPageMode.ROLEGHANT.toString());
 
 }

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandPoliticianConstants.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/api/pagecommands/PageCommandPoliticianConstants.java
@@ -1,7 +1,8 @@
 package com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands;
 
 import com.hack23.cia.web.impl.ui.application.views.common.pagelinks.api.PageModeMenuCommand;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PoliticianPageMode; // updated import
+import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PageMode; // updated import
+import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PoliticianPageMode;
 import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 
 /**
@@ -11,35 +12,35 @@ public interface PageCommandPoliticianConstants {
 
     /** The command politician ranking overview. */
     PageModeMenuCommand COMMAND_POLITICIAN_RANKING_OVERVIEW = new PageModeMenuCommand(
-        UserViews.POLITICIAN_RANKING_VIEW_NAME, "overview");
+        UserViews.POLITICIAN_RANKING_VIEW_NAME, PageMode.OVERVIEW);
 
     /** The command politician view. */
     PageModeMenuCommand COMMAND_POLITICIAN_VIEW = new PageModeMenuCommand(
-        UserViews.POLITICIAN_VIEW_NAME, "overview");
+        UserViews.POLITICIAN_VIEW_NAME, PageMode.OVERVIEW);
 
     /** The command politician ballot history. */
     PageModeMenuCommand COMMAND_POLITICIAN_BALLOT_HISTORY = new PageModeMenuCommand(
-        UserViews.POLITICIAN_VIEW_NAME, "ballothistory");
+        UserViews.POLITICIAN_VIEW_NAME, "BALLOTHISTORY");
 
     /** The command politician document history. */
     PageModeMenuCommand COMMAND_POLITICIAN_DOCUMENT_HISTORY = new PageModeMenuCommand(
-        UserViews.POLITICIAN_VIEW_NAME, "documenthistory");
+        UserViews.POLITICIAN_VIEW_NAME, PoliticianPageMode.DOCUMENTHISTORY.toString());
 
     /** The command politicians link. */
     PageModeMenuCommand COMMAND_POLITICIANS_LINK = new PageModeMenuCommand(
-            UserViews.POLITICIAN_RANKING_VIEW_NAME, "overview");
+            UserViews.POLITICIAN_RANKING_VIEW_NAME, PageMode.OVERVIEW);
 
     /** The command politician view overview. */
     PageModeMenuCommand COMMAND_POLITICIAN_VIEW_OVERVIEW = new PageModeMenuCommand(
-            UserViews.POLITICIAN_VIEW_NAME, "overview");
+            UserViews.POLITICIAN_VIEW_NAME, PageMode.OVERVIEW);
 
     /** The command politician view indicators. */
     PageModeMenuCommand COMMAND_POLITICIAN_VIEW_INDICATORS = new PageModeMenuCommand(
-            UserViews.POLITICIAN_VIEW_NAME, "indicators");
+            UserViews.POLITICIAN_VIEW_NAME, PageMode.INDICATORS);
 
     /** The command politician view roles. */
     PageModeMenuCommand COMMAND_POLITICIAN_VIEW_ROLES = new PageModeMenuCommand(
-            UserViews.POLITICIAN_VIEW_NAME, "roles");
+            UserViews.POLITICIAN_VIEW_NAME, "ROLES");
 
     /** The command politician role summary. */
     PageModeMenuCommand COMMAND_POLITICIAN_ROLE_SUMMARY = new PageModeMenuCommand(

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/CommitteeMenuItemFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/CommitteeMenuItemFactoryImpl.java
@@ -24,12 +24,8 @@ import org.springframework.stereotype.Service;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.ApplicationMenuItemFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.CommitteeMenuItemFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.CommitteeRankingMenuItemFactory;
-import com.hack23.cia.web.impl.ui.application.views.common.pagelinks.api.PageModeMenuCommand;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandCommitteeConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.rows.RowUtil;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.ChartIndicators;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.CommitteePageMode;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PageMode;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 import com.jarektoro.responsivelayout.ResponsiveRow;
 import com.vaadin.icons.VaadinIcons;
 import com.vaadin.ui.MenuBar;
@@ -75,45 +71,40 @@ public final class CommitteeMenuItemFactoryImpl extends AbstractMenuItemFactoryI
 		final MenuItem committeeItem = menuBar.addItem("Committee " + pageId, VaadinIcons.GROUP, null);
 
 		committeeItem.addItem(OVERVIEW_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME, PageMode.OVERVIEW, pageId));
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_OVERVIEW.createItemPageCommand(pageId));
 
 		final MenuItem rolesItem = committeeItem.addItem(ROLES_TEXT, VaadinIcons.GROUP, null);
 
-		rolesItem.addItem(CURRENT_MEMBERS_TEXT, VaadinIcons.USER, new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME,
-				CommitteePageMode.CURRENT_MEMBERS.toString(), pageId));
+		rolesItem.addItem(CURRENT_MEMBERS_TEXT, VaadinIcons.USER, 
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_CURRENT_MEMBERS.createItemPageCommand(pageId));
 
 		rolesItem.addItem(MEMBER_HISTORY_TEXT, VaadinIcons.CALENDAR_USER,
-				new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME,
-						CommitteePageMode.MEMBERHISTORY.toString(), pageId));
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_MEMBER_HISTORY.createItemPageCommand(pageId));
 
 		rolesItem.addItem(ROLE_GHANT_TEXT, VaadinIcons.LINE_CHART,
-				new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME, CommitteePageMode.ROLEGHANT.toString(), pageId));
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_ROLE_GHANT.createItemPageCommand(pageId));
 
 		final MenuItem documentItem = committeeItem.addItem(DOCUMENTS_TEXT, VaadinIcons.FILE_TEXT, null);
 
 		documentItem.addItem(DOCUMENT_ACTIVITY_TEXT, VaadinIcons.FILE_PROCESS,
-				new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME,
-						CommitteePageMode.DOCUMENTACTIVITY.toString(), pageId));
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_DOCUMENT_ACTIVITY.createItemPageCommand(pageId));
 
 		documentItem.addItem(DOCUMENT_HISTORY_TEXT, VaadinIcons.FILE_TREE,
-				new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME,
-						CommitteePageMode.DOCUMENT_HISTORY.toString(), pageId));
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_DOCUMENT_HISTORY.createItemPageCommand(pageId));
 
 		final MenuItem ballotItem = committeeItem.addItem(BALLOTS_TEXT, VaadinIcons.CLIPBOARD_TEXT, null);
 
 		ballotItem.addItem(BALLOT_DECISION_SUMMARY_TEXT, VaadinIcons.CLIPBOARD_CHECK,
-				new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME,
-						CommitteePageMode.BALLOTDECISIONSUMMARY.toString(), pageId));
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_BALLOT_DECISION_SUMMARY.createItemPageCommand(pageId));
 
 		ballotItem.addItem(DECISION_SUMMARY_TEXT, VaadinIcons.CLIPBOARD_PULSE,
-				new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME,
-						CommitteePageMode.DECISIONSUMMARY.toString(), pageId));
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_DECISION_SUMMARY.createItemPageCommand(pageId));
 
-		ballotItem.addItem(DECISION_TYPE_DAILY_SUMMARY_TEXT, VaadinIcons.CLIPBOARD_TEXT, new PageModeMenuCommand(
-				UserViews.COMMITTEE_VIEW_NAME, CommitteePageMode.DECISIONTYPEDAILYSUMMARY.toString(), pageId));
+		ballotItem.addItem(DECISION_TYPE_DAILY_SUMMARY_TEXT, VaadinIcons.CLIPBOARD_TEXT, 
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_DECISION_TYPE_DAILY_SUMMARY.createItemPageCommand(pageId));
 
-		ballotItem.addItem("Decision flow", VaadinIcons.LINE_CHART, new PageModeMenuCommand(
-				UserViews.COMMITTEE_VIEW_NAME, PageMode.CHARTS + "/" + ChartIndicators.DECISION_FLOW_CHART, pageId));
+		ballotItem.addItem("Decision flow", VaadinIcons.LINE_CHART, 
+				PageCommandCommitteeConstants.COMMAND_CHARTS_DECISION_FLOW.createItemPageCommand(pageId));
 
 		committeeItem.addItem(RANKING_PAGE_VISIT_TEXT, VaadinIcons.CLOCK,
 				COMMITTEE_RANKING_COMMAND_PAGEVISIT_HISTORY);
@@ -125,45 +116,39 @@ public final class CommitteeMenuItemFactoryImpl extends AbstractMenuItemFactoryI
 		final ResponsiveRow grid = RowUtil.createGridLayout(panelContent);
 
 		createButtonLink(grid, CURRENT_MEMBERS_TEXT, VaadinIcons.USER,
-				new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME,
-						CommitteePageMode.CURRENT_MEMBERS.toString(), pageId),
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_CURRENT_MEMBERS.createItemPageCommand(pageId),
 				CURRENT_MEMBERS_DESCRIPTION);
 
 		createButtonLink(grid, MEMBER_HISTORY_TEXT, VaadinIcons.CALENDAR_USER,
-				new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME,
-						CommitteePageMode.MEMBERHISTORY.toString(), pageId),
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_MEMBER_HISTORY.createItemPageCommand(pageId),
 				MEMBER_HISTORY_DESCRIPTION);
 
 		createButtonLink(grid, ROLE_GHANT_TEXT, VaadinIcons.LINE_CHART,
-				new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME, CommitteePageMode.ROLEGHANT.toString(), pageId),
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_ROLE_GHANT.createItemPageCommand(pageId),
 				ROLE_GHANT_DESCRIPTION);
 
 		createButtonLink(grid, DOCUMENT_ACTIVITY_TEXT, VaadinIcons.FILE_PROCESS,
-				new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME,
-						CommitteePageMode.DOCUMENTACTIVITY.toString(), pageId),
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_DOCUMENT_ACTIVITY.createItemPageCommand(pageId),
 				DOCUMENT_ACTIVITY_DESCRIPTION);
 
 		createButtonLink(grid, DOCUMENT_HISTORY_TEXT, VaadinIcons.FILE_TREE,
-				new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME,
-						CommitteePageMode.DOCUMENT_HISTORY.toString(), pageId),
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_DOCUMENT_HISTORY.createItemPageCommand(pageId),
 				DOCUMENT_HISTORY_DESCRIPTION);
 
 		createButtonLink(grid, BALLOT_DECISION_SUMMARY_TEXT, VaadinIcons.CLIPBOARD_CHECK,
-				new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME,
-						CommitteePageMode.BALLOTDECISIONSUMMARY.toString(), pageId),
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_BALLOT_DECISION_SUMMARY.createItemPageCommand(pageId),
 				BALLOT_DECISION_SUMMARY_DESCRIPTION);
 
 		createButtonLink(grid, DECISION_SUMMARY_TEXT, VaadinIcons.CLIPBOARD_PULSE,
-				new PageModeMenuCommand(UserViews.COMMITTEE_VIEW_NAME,
-						CommitteePageMode.DECISIONSUMMARY.toString(), pageId),
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_DECISION_SUMMARY.createItemPageCommand(pageId),
 				DECISION_SUMMARY_DESCRIPTION);
 
-		createButtonLink(grid, DECISION_TYPE_DAILY_SUMMARY_TEXT, VaadinIcons.CLIPBOARD_TEXT, new PageModeMenuCommand(
-				UserViews.COMMITTEE_VIEW_NAME, CommitteePageMode.DECISIONTYPEDAILYSUMMARY.toString(), pageId),
+		createButtonLink(grid, DECISION_TYPE_DAILY_SUMMARY_TEXT, VaadinIcons.CLIPBOARD_TEXT, 
+				PageCommandCommitteeConstants.COMMAND_COMMITTEE_DECISION_TYPE_DAILY_SUMMARY.createItemPageCommand(pageId),
 				DECISION_TYPE_DAILY_SUMMARY_DESCRIPTION);
 
-		createButtonLink(grid, "Decision flow", VaadinIcons.LINE_CHART, new PageModeMenuCommand(
-				UserViews.COMMITTEE_VIEW_NAME, PageMode.CHARTS + "/" + ChartIndicators.DECISION_FLOW_CHART, pageId),
+		createButtonLink(grid, "Decision flow", VaadinIcons.LINE_CHART, 
+				PageCommandCommitteeConstants.COMMAND_CHARTS_DECISION_FLOW.createItemPageCommand(pageId),
 				DECISION_FLOW_DESCRIPTION);
 
 		createButtonLink(grid, RANKING_PAGE_VISIT_TEXT, VaadinIcons.CHART,

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/MinistryMenuItemFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/MinistryMenuItemFactoryImpl.java
@@ -24,11 +24,8 @@ import org.springframework.stereotype.Service;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.ApplicationMenuItemFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.MinistryMenuItemFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.MinistryRankingMenuItemFactory;
-import com.hack23.cia.web.impl.ui.application.views.common.pagelinks.api.PageModeMenuCommand;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandMinistryConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.rows.RowUtil;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.MinistryPageMode;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PageMode;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 import com.jarektoro.responsivelayout.ResponsiveRow;
 import com.vaadin.icons.VaadinIcons;
 import com.vaadin.ui.MenuBar;
@@ -69,39 +66,34 @@ public final class MinistryMenuItemFactoryImpl extends AbstractMenuItemFactoryIm
 		final MenuItem ministryItem = menuBar.addItem("Ministry " + pageId, VaadinIcons.GROUP, null);
 
 		ministryItem.addItem(OVERVIEW_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, PageMode.OVERVIEW, pageId));
+				PageCommandMinistryConstants.COMMAND_MINISTRY_OVERVIEW.createItemPageCommand(pageId));
 		final MenuItem rolesItem = ministryItem.addItem(ROLES_TEXT, VaadinIcons.GROUP, null);
 
-		rolesItem.addItem(CURRENT_MEMBERS_TEXT, VaadinIcons.GROUP, new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-				MinistryPageMode.CURRENTMEMBERS.toString(), pageId));
+		rolesItem.addItem(CURRENT_MEMBERS_TEXT, VaadinIcons.GROUP, 
+				PageCommandMinistryConstants.COMMAND_MINISTRY_CURRENT_MEMBERS.createItemPageCommand(pageId));
 
-		rolesItem.addItem(MEMBER_HISTORY_TEXT, VaadinIcons.GROUP, new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-				MinistryPageMode.MEMBERHISTORY.toString(), pageId));
+		rolesItem.addItem(MEMBER_HISTORY_TEXT, VaadinIcons.GROUP, 
+				PageCommandMinistryConstants.COMMAND_MINISTRY_MEMBER_HISTORY.createItemPageCommand(pageId));
 
 		rolesItem.addItem(ROLE_GHANT_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, MinistryPageMode.ROLEGHANT.toString(), pageId));
+				PageCommandMinistryConstants.COMMAND_MINISTRY_ROLE_GHANT.createItemPageCommand(pageId));
 
 		rolesItem.addItem(GOVERNMENT_BODIES_HEADCOUNT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-						MinistryPageMode.GOVERNMENT_BODIES_HEADCOUNT.toString(), pageId));
+				PageCommandMinistryConstants.COMMAND_MINISTRY_GOVERNMENT_BODIES_HEADCOUNT.createItemPageCommand(pageId));
 
 		rolesItem.addItem(GOVERNMENT_BODIES_INCOME, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-						MinistryPageMode.GOVERNMENT_BODIES_INCOME.toString(), pageId));
+				PageCommandMinistryConstants.COMMAND_MINISTRY_GOVERNMENT_BODIES_INCOME.createItemPageCommand(pageId));
 
 		rolesItem.addItem(GOVERNMENT_BODIES_EXPENDITURE, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-						MinistryPageMode.GOVERNMENT_BODIES_EXPENDITURE.toString(), pageId));
+				PageCommandMinistryConstants.COMMAND_MINISTRY_GOVERNMENT_BODIES_EXPENDITURE.createItemPageCommand(pageId));
 
 		final MenuItem documentItem = ministryItem.addItem(DOCUMENTS_TEXT, VaadinIcons.GROUP, null);
 
 		documentItem.addItem(DOCUMENT_ACTIVITY_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-						MinistryPageMode.DOCUMENTACTIVITY.toString(), pageId));
+				PageCommandMinistryConstants.COMMAND_MINISTRY_DOCUMENT_ACTIVITY.createItemPageCommand(pageId));
 
 		documentItem.addItem(DOCUMENT_HISTORY_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-						MinistryPageMode.DOCUMENTHISTORY.toString(), pageId));
+				PageCommandMinistryConstants.COMMAND_MINISTRY_DOCUMENT_HISTORY.createItemPageCommand(pageId));
 
 		ministryItem.addItem(RANKING_PAGE_VISIT_TEXT, VaadinIcons.GROUP,
 				MINISTRY_RANKING_COMMAND_PAGEVISIT_HISTORY);
@@ -113,46 +105,39 @@ public final class MinistryMenuItemFactoryImpl extends AbstractMenuItemFactoryIm
 		final ResponsiveRow grid = RowUtil.createGridLayout(panelContent);
 
 		createButtonLink(grid, CURRENT_MEMBERS_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-						MinistryPageMode.CURRENTMEMBERS.toString(), pageId),
+				PageCommandMinistryConstants.COMMAND_MINISTRY_CURRENT_MEMBERS.createItemPageCommand(pageId),
 				CURRENT_MEMBERS_DESCRIPTION);
 
 		createButtonLink(grid, MEMBER_HISTORY_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-						MinistryPageMode.MEMBERHISTORY.toString(), pageId),
+				PageCommandMinistryConstants.COMMAND_MINISTRY_MEMBER_HISTORY.createItemPageCommand(pageId),
 				MEMBER_HISTORY_DESCRIPTION);
 
 		createButtonLink(grid, ROLE_GHANT_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, MinistryPageMode.ROLEGHANT.toString(), pageId),
+				PageCommandMinistryConstants.COMMAND_MINISTRY_ROLE_GHANT.createItemPageCommand(pageId),
 				ROLE_GHANT_DESCRIPTION);
 
 		createButtonLink(grid, GOVERNMENT_BODIES_HEADCOUNT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-						MinistryPageMode.GOVERNMENT_BODIES_HEADCOUNT.toString(), pageId),
+				PageCommandMinistryConstants.COMMAND_MINISTRY_GOVERNMENT_BODIES_HEADCOUNT.createItemPageCommand(pageId),
 				GOVERNMENT_BODIES_HEADCOUNT_DESCRIPTION);
 
 		createButtonLink(grid, GOVERNMENT_BODIES_INCOME, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-						MinistryPageMode.GOVERNMENT_BODIES_INCOME.toString(), pageId),
+				PageCommandMinistryConstants.COMMAND_MINISTRY_GOVERNMENT_BODIES_INCOME.createItemPageCommand(pageId),
 				GOVERNMENT_BODIES_INCOME_DESCRIPTION);
 
 		createButtonLink(grid, GOVERNMENT_BODIES_EXPENDITURE, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-						MinistryPageMode.GOVERNMENT_BODIES_EXPENDITURE.toString(), pageId),
+				PageCommandMinistryConstants.COMMAND_MINISTRY_GOVERNMENT_BODIES_EXPENDITURE.createItemPageCommand(pageId),
 				GOVERNMENT_BODIES_EXPENDITURE_DESCRIPTION);
 
 		createButtonLink(grid, DOCUMENT_ACTIVITY_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-						MinistryPageMode.DOCUMENTACTIVITY.toString(), pageId),
+				PageCommandMinistryConstants.COMMAND_MINISTRY_DOCUMENT_ACTIVITY.createItemPageCommand(pageId),
 				DOCUMENT_ACTIVITY_DESCRIPTION);
 
 		createButtonLink(grid, DOCUMENT_HISTORY_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME,
-						MinistryPageMode.DOCUMENTHISTORY.toString(), pageId),
+				PageCommandMinistryConstants.COMMAND_MINISTRY_DOCUMENT_HISTORY.createItemPageCommand(pageId),
 				DOCUMENT_HISTORY_DESCRIPTION);
 
 		createButtonLink(grid, RANKING_PAGE_VISIT_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.MINISTRY_VIEW_NAME, PageMode.PAGEVISITHISTORY, pageId),
+				PageCommandMinistryConstants.COMMAND_MINISTRY_PAGEVISIT_HISTORY.createItemPageCommand(pageId),
 				RANKING_PAGE_VISIT_DESC);
 
 	}

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/PartyMenuItemFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/PartyMenuItemFactoryImpl.java
@@ -27,6 +27,7 @@ import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.Party
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandPartyConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.text.MenuItemRankingPageVisitHistoryConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.rows.RowUtil;
+import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PartyPageMode;
 import com.jarektoro.responsivelayout.ResponsiveRow;
 import com.vaadin.icons.VaadinIcons;
 import com.vaadin.ui.MenuBar;

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/PartyMenuItemFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/PartyMenuItemFactoryImpl.java
@@ -24,12 +24,9 @@ import org.springframework.stereotype.Service;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.ApplicationMenuItemFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PartyMenuItemFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PartyRankingMenuItemFactory;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandPartyConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.text.MenuItemRankingPageVisitHistoryConstants;
-import com.hack23.cia.web.impl.ui.application.views.common.pagelinks.api.PageModeMenuCommand;
 import com.hack23.cia.web.impl.ui.application.views.common.rows.RowUtil;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PageMode;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PartyPageMode;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 import com.jarektoro.responsivelayout.ResponsiveRow;
 import com.vaadin.icons.VaadinIcons;
 import com.vaadin.ui.MenuBar;
@@ -63,67 +60,63 @@ public final class PartyMenuItemFactoryImpl extends AbstractMenuItemFactoryImpl
 		final ResponsiveRow grid = RowUtil.createGridLayout(panelContent);
 
 		createButtonLink(grid, CURRENT_LEADERS, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.CURRENTLEADERS.toString(), pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_CURRENT_LEADERS.createItemPageCommand(pageId),
 				CURRENT_LEADERS_DESCRIPTION);
 
 		createButtonLink(grid, LEADER_HISTORY, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.LEADERHISTORY.toString(), pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_LEADER_HISTORY.createItemPageCommand(pageId),
 				LEADER_HISTORY_DESCRIPTION);
 
 		createButtonLink(grid, CURRENT_MEMBERS_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.CURRENTMEMBERS.toString(), pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_CURRENT_MEMBERS.createItemPageCommand(pageId),
 				CURRENT_MEMBERS_DESCRIPTION);
 
 		createButtonLink(grid, MEMBER_HISTORY_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.MEMBERHISTORY.toString(), pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_MEMBER_HISTORY.createItemPageCommand(pageId),
 				MEMBER_HISTORY_DESCRIPTION);
 
 		createButtonLink(grid, GOVERMENT_ROLES, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.GOVERNMENTROLES.toString(), pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_GOVERNMENT_ROLES.createItemPageCommand(pageId),
 				GOVERMENT_ROLES_DESCRIPTION);
 
 		createButtonLink(grid, COMMITTEE_ROLES, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.COMMITTEEROLES.toString(), pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_COMMITTEE_ROLES.createItemPageCommand(pageId),
 				COMMITTEE_ROLES_DESCRIPTION);
 
 		createButtonLink(grid, ROLE_CHART_PARTY_LEADERS, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.ROLEGHANT.toString(), pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_ROLE_GHANT.createItemPageCommand(pageId),
 				ROLE_CHART_PARTY_LEADERS_DESCRIPTION);
 
 		createButtonLink(grid, DOCUMENT_ACTIVITY_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.DOCUMENTACTIVITY.toString(), pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_DOCUMENT_ACTIVITY.createItemPageCommand(pageId),
 				DOCUMENT_ACTIVITY_DESCRIPTION);
 
 		createButtonLink(grid, DOCUMENT_HISTORY_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.DOCUMENTHISTORY.toString(), pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_DOCUMENT_HISTORY.createItemPageCommand(pageId),
 				DOCUMENT_HISTORY_DESCRIPTION);
 
 		createButtonLink(grid, VOTE_HISTORY, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.VOTEHISTORY.toString(), pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_VOTE_HISTORY.createItemPageCommand(pageId),
 				VOTE_HISTORY);
 
 		createButtonLink(grid, BALLOT_DECISION_SUMMARY_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME,
-						PartyPageMode.COMMITTEEBALLOTDECISIONSUMMARY.toString(), pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_BALLOT_DECISION_SUMMARY.createItemPageCommand(pageId),
 				BALLOT_DECISION_SUMMARY_DESCRIPTION);
 
 		createButtonLink(grid, PARTY_WON_DAILY_SUMMARY_CHART, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME,
-						PartyPageMode.PARTYWONDAILYSUMMARYCHART.toString(), pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_WON_DAILY_SUMMARY_CHART.createItemPageCommand(pageId),
 				PARTY_WON_DAILY_SUMMARY_CHART_DESCRIPTION);
 
 		createButtonLink(grid, PartyPageMode.PARTYAGAINSTCOALATIONSSUMMARY.toString(), VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME,
-						PartyPageMode.PARTYAGAINSTCOALATIONSSUMMARY.toString(), pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_AGAINST_COALITIONS_SUMMARY.createItemPageCommand(pageId),
 				PARTY_AGAINST_COALATIONS_SUMMARY_DESCRIPTION);
 
 		createButtonLink(grid, PartyPageMode.PARTYSUPPORTSUMMARY.toString(), VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME,
-						PartyPageMode.PARTYSUPPORTSUMMARY.toString(), pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_SUPPORT_SUMMARY.createItemPageCommand(pageId),
 				PARTY_SUPPORT_SUMMARY_DESCRIPTION);
 
 		createButtonLink(grid, RANKING_PAGE_VISIT_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PageMode.PAGEVISITHISTORY, pageId),
+				PageCommandPartyConstants.COMMAND_PARTY_PAGE_VISIT_HISTORY.createItemPageCommand(pageId),
 				MenuItemRankingPageVisitHistoryConstants.PAGE_VISIT_HISTORY_DESCRIPTION);
 
 	}
@@ -139,62 +132,58 @@ public final class PartyMenuItemFactoryImpl extends AbstractMenuItemFactoryImpl
 		final MenuItem partyItem = menuBar.addItem("Party " + pageId, VaadinIcons.GROUP, null);
 
 		partyItem.addItem(OVERVIEW_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PageMode.OVERVIEW, pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_OVERVIEW.createItemPageCommand(pageId));
 
 		final MenuItem rolesItem = partyItem.addItem(ROLES_TEXT, VaadinIcons.GROUP, null);
 
 		rolesItem.addItem(CURRENT_LEADERS, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.CURRENTLEADERS.toString(), pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_CURRENT_LEADERS.createItemPageCommand(pageId));
 
 		rolesItem.addItem(LEADER_HISTORY, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.LEADERHISTORY.toString(), pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_LEADER_HISTORY.createItemPageCommand(pageId));
 
 		rolesItem.addItem(CURRENT_MEMBERS_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.CURRENTMEMBERS.toString(), pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_CURRENT_MEMBERS.createItemPageCommand(pageId));
 
 		rolesItem.addItem(MEMBER_HISTORY_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.MEMBERHISTORY.toString(), pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_MEMBER_HISTORY.createItemPageCommand(pageId));
 
 		rolesItem.addItem(GOVERMENT_ROLES, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.GOVERNMENTROLES.toString(), pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_GOVERNMENT_ROLES.createItemPageCommand(pageId));
 
 		rolesItem.addItem(COMMITTEE_ROLES, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.COMMITTEEROLES.toString(), pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_COMMITTEE_ROLES.createItemPageCommand(pageId));
 
 		rolesItem.addItem(ROLE_CHART_PARTY_LEADERS, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.ROLEGHANT.toString(), pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_ROLE_GHANT.createItemPageCommand(pageId));
 
 		final MenuItem documentItem = partyItem.addItem(DOCUMENTS_TEXT, VaadinIcons.GROUP, null);
 
 		documentItem.addItem(DOCUMENT_ACTIVITY_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.DOCUMENTACTIVITY.toString(), pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_DOCUMENT_ACTIVITY.createItemPageCommand(pageId));
 
 		documentItem.addItem(DOCUMENT_HISTORY_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.DOCUMENTHISTORY.toString(), pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_DOCUMENT_HISTORY.createItemPageCommand(pageId));
 
 		final MenuItem ballotItem = partyItem.addItem(BALLOTS_TEXT, VaadinIcons.GROUP, null);
 
 		ballotItem.addItem(VOTE_HISTORY, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PartyPageMode.VOTEHISTORY.toString(), pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_VOTE_HISTORY.createItemPageCommand(pageId));
 
 		ballotItem.addItem(BALLOT_DECISION_SUMMARY_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME,
-						PartyPageMode.COMMITTEEBALLOTDECISIONSUMMARY.toString(), pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_BALLOT_DECISION_SUMMARY.createItemPageCommand(pageId));
 
 		ballotItem.addItem(PARTY_WON_DAILY_SUMMARY_CHART, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME,
-						PartyPageMode.PARTYWONDAILYSUMMARYCHART.toString(), pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_WON_DAILY_SUMMARY_CHART.createItemPageCommand(pageId));
 
 		ballotItem.addItem(PartyPageMode.PARTYAGAINSTCOALATIONSSUMMARY.toString(), VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME,
-						PartyPageMode.PARTYAGAINSTCOALATIONSSUMMARY.toString(), pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_AGAINST_COALITIONS_SUMMARY.createItemPageCommand(pageId));
 
 		ballotItem.addItem(PartyPageMode.PARTYSUPPORTSUMMARY.toString(), VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME,
-						PartyPageMode.PARTYSUPPORTSUMMARY.toString(), pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_SUPPORT_SUMMARY.createItemPageCommand(pageId));
 
 		partyItem.addItem(RANKING_PAGE_VISIT_TEXT, VaadinIcons.GROUP,
-				new PageModeMenuCommand(UserViews.PARTY_VIEW_NAME, PageMode.PAGEVISITHISTORY, pageId));
+				PageCommandPartyConstants.COMMAND_PARTY_PAGE_VISIT_HISTORY.createItemPageCommand(pageId));
 
 	}
 

--- a/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/PoliticianMenuItemFactoryImpl.java
+++ b/citizen-intelligence-agency/src/main/java/com/hack23/cia/web/impl/ui/application/views/common/menufactory/impl/PoliticianMenuItemFactoryImpl.java
@@ -24,11 +24,8 @@ import org.springframework.stereotype.Service;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.ApplicationMenuItemFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PoliticianMenuItemFactory;
 import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.PoliticianRankingMenuItemFactory;
-import com.hack23.cia.web.impl.ui.application.views.common.pagelinks.api.PageModeMenuCommand;
+import com.hack23.cia.web.impl.ui.application.views.common.menufactory.api.pagecommands.PageCommandPoliticianConstants;
 import com.hack23.cia.web.impl.ui.application.views.common.rows.RowUtil;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PageMode;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.PoliticianPageMode;
-import com.hack23.cia.web.impl.ui.application.views.common.viewnames.UserViews;
 import com.jarektoro.responsivelayout.ResponsiveRow;
 import com.vaadin.icons.VaadinIcons;
 import com.vaadin.ui.MenuBar;
@@ -152,47 +149,39 @@ public final class PoliticianMenuItemFactoryImpl extends AbstractMenuItemFactory
                 final ResponsiveRow grid = RowUtil.createGridLayout(panelContent);
 
                 createButtonLink(grid, INDICATORS_TEXT, VaadinIcons.CHART,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME, PageMode.INDICATORS, pageId),
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_VIEW_INDICATORS.createItemPageCommand(pageId),
                                 INDICATORS_DESCRIPTION);
 
                 createButtonLink(grid, TOTAL_EXPERIENCE, VaadinIcons.USER_CLOCK,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME,
-                                                PoliticianPageMode.ROLESUMMARY.toString(), pageId),
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_ROLE_SUMMARY.createItemPageCommand(pageId),
                                 TOTAL_EXPERIENCE_DESCRIPTION);
 
                 createButtonLink(grid, ROLE_LIST, VaadinIcons.LIST,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME,
-                                                PoliticianPageMode.ROLELIST.toString(), pageId),
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_ROLE_LIST.createItemPageCommand(pageId),
                                 ROLE_LIST_DESCRIPTION);
 
                 createButtonLink(grid, ROLE_GHANT_TEXT, VaadinIcons.USER_CLOCK,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME,
-                                                PoliticianPageMode.ROLEGHANT.toString(), pageId),
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_ROLE_GHANT.createItemPageCommand(pageId),
                                 ROLE_GHANT_DESCRIPTION);
 
                 createButtonLink(grid, DOCUMENT_ACTIVITY_TEXT, VaadinIcons.FILE_TEXT,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME,
-                                                PoliticianPageMode.DOCUMENTACTIVITY.toString(), pageId),
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_DOCUMENT_HISTORY.createItemPageCommand(pageId),
                                 DOCUMENT_ACTIVITY_DESCRIPTION);
 
                 createButtonLink(grid, DOCUMENT_HISTORY_TEXT, VaadinIcons.CHART,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME,
-                                                PoliticianPageMode.DOCUMENTHISTORY.toString(), pageId),
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_DOCUMENT_HISTORY.createItemPageCommand(pageId),
                                 DOCUMENT_HISTORY_DESCRIPTION);
 
                 createButtonLink(grid, VOTE_HISTORY, VaadinIcons.CHECK_CIRCLE,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME,
-                                                PoliticianPageMode.VOTEHISTORY.toString(), pageId),
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_BALLOT_HISTORY.createItemPageCommand(pageId),
                                 VOTE_HISTORY_DESCRIPTION);
 
                 createButtonLink(grid, BALLOT_DECISION_SUMMARY_TEXT, VaadinIcons.CHECK,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME,
-                                                PoliticianPageMode.BALLOTDECISIONSUMMARY.toString(), pageId),
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_BALLOT_HISTORY.createItemPageCommand(pageId),
                                 BALLOT_DECISION_SUMMARY_DESCRIPTION);
 
                 createButtonLink(grid, PAGE_VISIT_HISTORY_TEXT, VaadinIcons.CHART,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME, PageMode.PAGEVISITHISTORY,
-                                                pageId),
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_VIEW_OVERVIEW.createItemPageCommand(pageId),
                                 PAGE_VISIT_HISTORY_DESCRIPTION);
         }
 
@@ -215,46 +204,38 @@ public final class PoliticianMenuItemFactoryImpl extends AbstractMenuItemFactory
                 final MenuItem politicianItem = menuBar.addItem("Politician " + pageId, VaadinIcons.USER, null);
 
                 politicianItem.addItem(OVERVIEW_TEXT, VaadinIcons.DASHBOARD,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME, PageMode.OVERVIEW, pageId));
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_VIEW_OVERVIEW.createItemPageCommand(pageId));
 
                 politicianItem.addItem(INDICATORS_TEXT, VaadinIcons.CHART,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME, PageMode.INDICATORS, pageId));
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_VIEW_INDICATORS.createItemPageCommand(pageId));
 
                 final MenuItem rolesItem = politicianItem.addItem(ROLES_TEXT, VaadinIcons.TAGS, null);
 
                 rolesItem.addItem(TOTAL_EXPERIENCE, VaadinIcons.USER_CLOCK,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME,
-                                                PoliticianPageMode.ROLESUMMARY.toString(), pageId));
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_ROLE_SUMMARY.createItemPageCommand(pageId));
 
                 rolesItem.addItem(ROLE_LIST, VaadinIcons.LIST,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME,
-                                                PoliticianPageMode.ROLELIST.toString(), pageId));
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_ROLE_LIST.createItemPageCommand(pageId));
 
                 rolesItem.addItem(ROLE_GHANT_TEXT, VaadinIcons.USER_CLOCK,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME,
-                                                PoliticianPageMode.ROLEGHANT.toString(), pageId));
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_ROLE_GHANT.createItemPageCommand(pageId));
 
                 final MenuItem documentItem = politicianItem.addItem(DOCUMENTS_TEXT, VaadinIcons.FILE_TEXT, null);
 
                 documentItem.addItem(DOCUMENT_ACTIVITY_TEXT, VaadinIcons.FILE_TEXT,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME,
-                                                PoliticianPageMode.DOCUMENTACTIVITY.toString(), pageId));
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_DOCUMENT_HISTORY.createItemPageCommand(pageId));
 
                 documentItem.addItem(DOCUMENT_HISTORY_TEXT, VaadinIcons.CHART,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME,
-                                                PoliticianPageMode.DOCUMENTHISTORY.toString(), pageId));
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_DOCUMENT_HISTORY.createItemPageCommand(pageId));
 
                 final MenuItem ballotItem = politicianItem.addItem(BALLOTS_TEXT, VaadinIcons.CHECK, null);
 
                 ballotItem.addItem(VOTE_HISTORY, VaadinIcons.CHECK_CIRCLE,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME,
-                                                PoliticianPageMode.VOTEHISTORY.toString(), pageId));
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_BALLOT_HISTORY.createItemPageCommand(pageId));
 
                 ballotItem.addItem(BALLOT_DECISION_SUMMARY_TEXT, VaadinIcons.CHECK,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME,
-                                                PoliticianPageMode.BALLOTDECISIONSUMMARY.toString(), pageId));
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_BALLOT_HISTORY.createItemPageCommand(pageId));
 
                 politicianItem.addItem(PAGE_VISIT_HISTORY_TEXT, VaadinIcons.CHART,
-                                new PageModeMenuCommand(UserViews.POLITICIAN_VIEW_NAME, PageMode.PAGEVISITHISTORY,
-                                                pageId));
+                                PageCommandPoliticianConstants.COMMAND_POLITICIAN_VIEW_OVERVIEW.createItemPageCommand(pageId));
         }}


### PR DESCRIPTION
Refactor `PartyMenuItemFactoryImpl`, `MinistryMenuItemFactoryImpl`, and `CommitteeMenuItemFactoryImpl` to use constants from respective `PageCommand` constants interfaces.

* **PartyMenuItemFactoryImpl**
  - Replace direct `new PageModeMenuCommand()` instances with constants from `PageCommandPartyConstants`.
  - Add constants for various party-related commands in `PageCommandPartyConstants`.

* **MinistryMenuItemFactoryImpl**
  - Replace direct `new PageModeMenuCommand()` instances with constants from `PageCommandMinistryConstants`.
  - Add constants for various ministry-related commands in `PageCommandMinistryConstants`.

* **CommitteeMenuItemFactoryImpl**
  - Replace direct `new PageModeMenuCommand()` instances with constants from `PageCommandCommitteeConstants`.
  - Add constants for various committee-related commands in `PageCommandCommitteeConstants`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hack23/cia/pull/7158?shareId=0df326cd-1607-40ff-9d6e-6a9a4e41a39d).